### PR TITLE
Add missing setup-shell.desktop file, renamed to eos-setup-shell.desk…

### DIFF
--- a/eos-installer-data/Makefile.am
+++ b/eos-installer-data/Makefile.am
@@ -20,12 +20,13 @@ sessiondir = $(datadir)/gnome-session/sessions
 session_DATA = eos-installer.session
 
 desktopdir = $(datadir)/gdm/greeter/applications
-desktop_DATA =	eos-installer.desktop $(NULL)
+desktop_DATA =	eos-installer.desktop eos-setup-shell.desktop $(NULL)
 
 EXTRA_DIST =						\
 	20-eos-installer.rules  		\
 	eos-installer.desktop.in.in		\
 	eos-installer.session			\
+	eos-setup-shell.desktop 		\
 	$(NULL)
 
 CLEANFILES =						\

--- a/eos-installer-data/eos-installer.session
+++ b/eos-installer-data/eos-installer.session
@@ -1,3 +1,3 @@
 [GNOME Session]
 Name=EOS Installer
-RequiredComponents=setup-shell;eos-installer;gnome-settings-daemon;
+RequiredComponents=eos-setup-shell;eos-installer;gnome-settings-daemon;

--- a/eos-installer-data/eos-setup-shell.desktop
+++ b/eos-installer-data/eos-setup-shell.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=GNOME Shell
+Exec=gnome-shell --mode=initial-setup
+X-GNOME-AutoRestart=true
+X-GNOME-Autostart-Phase=WindowManager
+X-GNOME-Provides=panel;windowmanager;
+X-GNOME-Autostart-Notify=true


### PR DESCRIPTION
…top due to conflicts with g-i-s
