### PR TITLE
Add missing setup-shell.desktop file, renamed to eos-setup-shell.desk…

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -2,3 +2,4 @@ debian/tmp/usr/share/locale/*
 debian/tmp/usr/lib/eos-installer/*
 debian/tmp/usr/share/gnome-session/sessions/eos-installer.session
 debian/tmp/usr/share/gdm/greeter/applications/eos-installer.desktop
+debian/tmp/usr/share/gdm/greeter/applications/eos-setup-shell.desktop


### PR DESCRIPTION
…top due to conflicts with g-i-s
