### PR TITLE
Don't exclude removable devices

### DIFF
--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -225,9 +225,6 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       if (udisks_drive_get_optical(drive))
         continue;
 
-      if (udisks_drive_get_removable(drive))
-        continue;
-
       if (udisks_drive_get_ejectable(drive))
         continue;
 


### PR DESCRIPTION
udisks determination of what is a removable device is fundamentally
inaccurate, so we're actually excluding some nonremovable devices here
too. Avoid this flawed test.

https://bugs.freedesktop.org/show_bug.cgi?id=49844
https://phabricator.endlessm.com/T12103
