### PR TITLE
T13654 replace install{,er} with reformat{,ter}

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -403,7 +403,7 @@ gis_diskimage_page_constructed (GObject *object)
 static void
 gis_diskimage_page_locale_changed (GisPage *page)
 {
-  gis_page_set_title (page, _("Install Endless OS"));
+  gis_page_set_title (page, _("Reformat this computer with Endless OS"));
 }
 
 static void

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -122,7 +122,7 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
       if (udisks_drive_get_size(drive) < gis_store_get_required_size())
         {
           gchar *msg = g_strdup_printf (
-            _("The location you have chosen is too small - you need more space to install %s (%.02f GB)"),
+            _("The location you have chosen is too small - you need more space to reformat with %s (%.02f GB)"),
             gis_store_get_image_name(), gis_store_get_required_size()/1024.0/1024.0/1024.0);
           gtk_label_set_text (OBJ (GtkLabel*, "too_small_label"), msg);
           g_free (msg);

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
@@ -24,7 +24,7 @@
       <object class="GtkLabel" id="overview">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Select the location where you'd like to install Endless OS</property>
+        <property name="label" translatable="yes">Select the disk you'd like to reformat with Endless OS</property>
       </object>
       <packing>
         <property name="expand">False</property>
@@ -157,7 +157,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">6</property>
-                <property name="label" translatable="yes">It looks like you have multiple partitions on this disk (for example drive C: and D:). Installing Endless OS will erase &lt;b&gt;all partitions&lt;/b&gt; on the selected disk. Please click here to confirm.</property>
+                <property name="label" translatable="yes">It looks like you have multiple partitions on this disk (for example drive C: and D:). Reformatting with Endless OS will erase &lt;b&gt;all partitions&lt;/b&gt; on the selected disk. Please click here to confirm.</property>
                 <property name="use_markup">True</property>
                 <property name="wrap">True</property>
                 <property name="max_width_chars">40</property>
@@ -206,7 +206,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">12</property>
-                <property name="label" translatable="yes">The location you have chosen is too small - you need more space to install %s</property>
+                <property name="label" translatable="yes">The location you have chosen is too small - you need more space to reformat with %s (%.02f GB)</property>
                 <property name="wrap">True</property>
                 <property name="wrap_mode">word-char</property>
                 <property name="max_width_chars">50</property>

--- a/gnome-image-installer/pages/finished/gis-finished-page.c
+++ b/gnome-image-installer/pages/finished/gis-finished-page.c
@@ -114,7 +114,7 @@ gis_finished_page_locale_changed (GisPage *page)
 {
   if (gis_store_get_error() == NULL)
     {
-      gis_page_set_title (page, _("Installation Finished"));
+      gis_page_set_title (page, _("Reformatting Finished"));
     }
   else
     {

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -157,7 +157,7 @@ gis_install_page_prepare_write (GisPage *page, GError **error)
   if (fd < 0)
     {
       g_prefix_error (&e,
-                      "Error extracing fd with handle %d from D-Bus message: ",
+                      "Error extracting fd with handle %d from D-Bus message: ",
                       g_variant_get_handle (fd_index));
       g_propagate_error (error, e);
       return FALSE;

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -603,7 +603,7 @@ gis_install_page_constructed (GObject *object)
 static void
 gis_install_page_locale_changed (GisPage *page)
 {
-  gis_page_set_title (page, _("Installing"));
+  gis_page_set_title (page, _("Reformatting"));
 }
 
 static void


### PR DESCRIPTION
Update strings and function names to capture the new terminology for replacing
your OS entirely with Endless: reformat. This should be less ambiguous than
having two user-visible processes known as install, the Windows dual-boot
process (non-destructive, reversible) and the Linux reformat process (very
destructive, non-reversible).

https://phabricator.endlessm.com/T13654
