### PR TITLE
Enable compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,15 @@ fi
 AC_SUBST(INITIAL_SETUP_CFLAGS)
 AC_SUBST(INITIAL_SETUP_LIBS)
 
-GNOME_COMPILE_WARNINGS([error])
+# -Wno-declaration-after-statement:
+#   Mixed decls are used a lot and are harmless.
+# -Wno-packed:
+#   gpt.h structs are naturally packed, so the compiler warns that the
+#   attribute is unnecessary. I am not quite comfortable removing it even
+#   though I believe the compiler's argument: it has value as documentation.
+AX_COMPILER_FLAGS([WARN_CFLAGS], [WARN_LDFLAGS], [], [],
+                  [-Wno-declaration-after-statement -Wno-packed])
+
 GNOME_MAINTAINER_MODE_DEFINES
 
 AC_SUBST(CFLAGS)

--- a/gnome-image-installer/Makefile.am
+++ b/gnome-image-installer/Makefile.am
@@ -29,6 +29,8 @@ gis-assistant-resources.h: $(gissrcdir)/gis-assistant.gresource.xml $(resource_f
 	$(AM_V_GEN) $(GLIB_COMPILE_RESOURCES) --target=$@ --sourcedir=$(gissrcdir) --generate-header $<
 BUILT_SOURCES += gis-assistant-resources.c gis-assistant-resources.h
 
+gnome_image_installer_CFLAGS = \
+	$(WARN_CFLAGS)
 gnome_image_installer_SOURCES = \
 	$(BUILT_SOURCES) \
 	gnome-image-installer.c gnome-image-installer.h
@@ -47,4 +49,5 @@ gnome_image_installer_LDADD =	\
 	pages/finished/libgisfinished.la \
 	$(INITIAL_SETUP_LIBS) \
 	$(IMAGE_INSTALLER_LIBS) \
-	-lm -lz
+	-lm -lz \
+	$(WARN_LDFLAGS)

--- a/gnome-image-installer/gnome-image-installer.c
+++ b/gnome-image-installer/gnome-image-installer.c
@@ -32,14 +32,6 @@
 #include <glib/gi18n.h>
 #include <udisks/udisks.h>
 
-#ifdef HAVE_CLUTTER
-#include <clutter-gtk/clutter-gtk.h>
-#endif
-
-#ifdef HAVE_CHEESE
-#include <cheese-gtk.h>
-#endif
-
 #include "pages/language/cc-common-language.h"
 #include "pages/language/gis-language-page.h"
 #include "pages/keyboard/gis-keyboard-page.h"
@@ -58,12 +50,6 @@
 /* main {{{1 */
 
 static gboolean force_new_user_mode;
-static const gchar *system_setup_pages[] = {
-    "account",
-    "display",
-    "endless_eula",
-    "location"
-};
 
 typedef void (*PreparePage) (GisDriver *driver);
 
@@ -360,19 +346,7 @@ gis_page_get_type();
   bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
   textdomain (GETTEXT_PACKAGE);
 
-#ifdef HAVE_CHEESE
-  cheese_gtk_init (NULL, NULL);
-#endif
-
   gtk_init (&argc, &argv);
-  ev_init ();
-
-#if HAVE_CLUTTER
-  if (gtk_clutter_init (NULL, NULL) != CLUTTER_INIT_SUCCESS) {
-    g_critical ("Clutter-GTK init failed");
-    exit (1);
-  }
-#endif
 
   gis_ensure_login_keyring ("gis");
 
@@ -387,7 +361,6 @@ gis_page_get_type();
 
   g_object_unref (driver);
   g_option_context_free (context);
-  ev_shutdown ();
 
   return status;
 }

--- a/gnome-image-installer/gnome-image-installer.c
+++ b/gnome-image-installer/gnome-image-installer.c
@@ -195,7 +195,7 @@ read_keys (const gchar *path)
 }
 
 static void
-mount_and_read_keys ()
+mount_and_read_keys (void)
 {
   GError *error = NULL;
   UDisksClient *client = udisks_client_new_sync(NULL, &error);
@@ -241,7 +241,7 @@ mount_and_read_keys ()
 }
 
 static gboolean
-check_for_live_boot ()
+check_for_live_boot (void)
 {
   const gchar *force = g_getenv ("EI_FORCE_LIVE_BOOT");
   GError *error = NULL;

--- a/gnome-image-installer/gnome-image-installer.c
+++ b/gnome-image-installer/gnome-image-installer.c
@@ -47,6 +47,8 @@
 #include "pages/finished/gis-finished-page.h"
 #include "pages/install/gis-install-page.h"
 
+#include "util/gis-store.h"
+
 /* main {{{1 */
 
 static gboolean force_new_user_mode;

--- a/gnome-image-installer/pages/diskimage/Makefile.am
+++ b/gnome-image-installer/pages/diskimage/Makefile.am
@@ -20,9 +20,9 @@ libgisdiskimage_la_SOURCES =			\
 	gis-diskimage-page.c gis-diskimage-page.h	\
 	$(BUILT_SOURCES)
 
-libgisdiskimage_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util"
+libgisdiskimage_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util" $(WARN_CFLAGS)
 libgisdiskimage_la_LIBADD = $(INITIAL_SETUP_LIBS) $(IMAGE_INSTALLER_LIBS) ./../../util/libgiiutil.la
-libgisdiskimage_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
+libgisdiskimage_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined $(WARN_LDFLAGS)
 
 EXTRA_DIST =	\
 	diskimage.gresource.xml	\

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -525,9 +525,6 @@ gis_diskimage_page_mount (GisPage *page)
 static void
 gis_diskimage_page_shown (GisPage *page)
 {
-  GisDiskImagePage *diskimage = GIS_DISK_IMAGE_PAGE (page);
-  GisDiskImagePagePrivate *priv = gis_diskimage_page_get_instance_private (diskimage);
-
   gis_driver_save_data (GIS_PAGE (page)->driver);
 
   gis_diskimage_page_mount (page);

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -55,7 +55,6 @@ G_DEFINE_TYPE_WITH_PRIVATE (GisDiskImagePage, gis_diskimage_page, GIS_TYPE_PAGE)
 #define WID(name) OBJ(GtkWidget*,name)
 
 G_DEFINE_QUARK(image-error, gis_image_error);
-#define GIS_IMAGE_ERROR gis_image_error_quark()
 
 /* A device-mapped copy of endless.img used in image boots.
  * We prefer to use this to endless.img from the filesystem for two reasons:

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.h
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.h
@@ -53,6 +53,9 @@ GType gis_diskimage_page_get_type (void);
 
 void gis_prepare_diskimage_page (GisDriver *driver);
 
+GQuark gis_image_error_quark (void);
+#define GIS_IMAGE_ERROR gis_image_error_quark()
+
 G_END_DECLS
 
 #endif /* __GIS_DISK_IMAGE_PAGE_H__ */

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.ui
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.ui
@@ -16,6 +16,8 @@
       <column type="gchararray"/>
       <!-- column-name align -->
       <column type="PangoAlignment"/>
+      <!-- column-name required_size -->
+      <column type="guint64"/>
     </columns>
   </object>
   <object class="GtkBox" id="diskimage-page">

--- a/gnome-image-installer/pages/disktarget/Makefile.am
+++ b/gnome-image-installer/pages/disktarget/Makefile.am
@@ -19,9 +19,9 @@ libgisdisktarget_la_SOURCES =			\
 	gis-disktarget-page.c gis-disktarget-page.h	\
 	$(BUILT_SOURCES)
 
-libgisdisktarget_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util"
+libgisdisktarget_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util" $(WARN_CFLAGS)
 libgisdisktarget_la_LIBADD = $(INITIAL_SETUP_LIBS) $(IMAGE_INSTALLER_LIBS)
-libgisdisktarget_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
+libgisdisktarget_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined $(WARN_LDFLAGS)
 
 EXTRA_DIST =	\
 	disktarget.gresource.xml	\

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -39,7 +39,6 @@
 #include <errno.h>
 
 G_DEFINE_QUARK(disk-error, gis_disk_error);
-#define GIS_DISK_ERROR gis_disk_error_quark()
 
 struct _GisDiskTargetPagePrivate {
   UDisksClient *client;

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.h
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.h
@@ -53,6 +53,9 @@ GType gis_disktarget_page_get_type (void);
 
 void gis_prepare_disktarget_page (GisDriver *driver);
 
+GQuark gis_disk_error_quark (void);
+#define GIS_DISK_ERROR gis_disk_error_quark()
+
 G_END_DECLS
 
 #endif /* __GIS_DISK_TARGET_PAGE_H__ */

--- a/gnome-image-installer/pages/finished/Makefile.am
+++ b/gnome-image-installer/pages/finished/Makefile.am
@@ -20,9 +20,9 @@ libgisfinished_la_SOURCES =			\
 	gis-finished-page.c gis-finished-page.h	\
 	$(BUILT_SOURCES)
 
-libgisfinished_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../../util" -I "$(srcdir)/../.."
+libgisfinished_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../../util" -I "$(srcdir)/../.." $(WARN_CFLAGS)
 libgisfinished_la_LIBADD = $(INITIAL_SETUP_LIBS) $(IMAGE_INSTALLER_CFLAGS)
-libgisfinished_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
+libgisfinished_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined $(WARN_LDFLAGS)
 
 EXTRA_DIST =	\
 	finished.gresource.xml	\

--- a/gnome-image-installer/pages/finished/gis-finished-page.c
+++ b/gnome-image-installer/pages/finished/gis-finished-page.c
@@ -72,8 +72,6 @@ toggle_leds (GisPage *page)
 static void
 gis_finished_page_shown (GisPage *page)
 {
-  GisFinishedPage *summary = GIS_FINISHED_PAGE (page);
-  GisFinishedPagePrivate *priv = gis_finished_page_get_instance_private (summary);
   GError *error = gis_store_get_error();
 
   gis_driver_save_data (GIS_PAGE (page)->driver);

--- a/gnome-image-installer/pages/install/Makefile.am
+++ b/gnome-image-installer/pages/install/Makefile.am
@@ -20,9 +20,9 @@ libgisinstall_la_SOURCES =			\
 	gis-install-page.c gis-install-page.h	\
 	$(BUILT_SOURCES)
 
-libgisinstall_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util"
+libgisinstall_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) $(IMAGE_INSTALLER_CFLAGS) -I "$(srcdir)/../../../gnome-initial-setup" -I "$(srcdir)/../.." -I "$(srcdir)/../../util" $(WARN_CFLAGS)
 libgisinstall_la_LIBADD = $(INITIAL_SETUP_LIBS) $(IMAGE_INSTALLER_CFLAGS) ./../../util/libgiiutil.la
-libgisinstall_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
+libgisinstall_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined $(WARN_LDFLAGS)
 
 EXTRA_DIST =	\
 	install.gresource.xml	\

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -617,13 +617,13 @@ gis_install_page_verify (GisPage *page)
   const gchar *signature_path = gis_store_get_image_signature ();
   GFile *signature = g_file_new_for_path (signature_path);
   gint outfd;
-  gchar *args[] = { "gpg",
+  const gchar * const args[] = { "gpg",
                     "--enable-progress-filter", "--status-fd", "1",
                     /* Trust the one key in this keyring, and no others */
                     "--keyring", IMAGE_KEYRING,
                     "--no-default-keyring",
                     "--trust-model", "always",
-                    "--verify", (gchar *) signature_path, image_path, NULL };
+                    "--verify", signature_path, image_path, NULL };
   GError *error = NULL;
 
   if (!g_file_query_exists (signature, NULL))
@@ -635,7 +635,7 @@ gis_install_page_verify (GisPage *page)
       goto out;
     }
 
-  if (!g_spawn_async_with_pipes (NULL, args, NULL,
+  if (!g_spawn_async_with_pipes (NULL, (gchar **) args, NULL,
                                  G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
                                  NULL, NULL, &priv->gpg,
                                  NULL, &outfd, NULL, &error))

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -67,7 +67,6 @@ typedef struct _GisInstallPagePrivate GisInstallPagePrivate;
 G_DEFINE_TYPE_WITH_PRIVATE (GisInstallPage, gis_install_page, GIS_TYPE_PAGE);
 
 G_DEFINE_QUARK(install-error, gis_install_error);
-#define GIS_INSTALL_ERROR gis_install_error_quark()
 
 #define OBJ(type,name) ((type)gtk_builder_get_object(GIS_PAGE(page)->builder,(name)))
 #define WID(name) OBJ(GtkWidget*,name)

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -383,8 +383,6 @@ gis_install_page_is_efi_system (GisPage *page)
 static gboolean
 gis_install_page_convert_to_mbr (GisPage *page, GError **error)
 {
-  GisInstallPage *install = GIS_INSTALL_PAGE (page);
-  GisInstallPagePrivate *priv = gis_install_page_get_instance_private (install);
   UDisksBlock *block = UDISKS_BLOCK (gis_store_get_object (GIS_STORE_BLOCK_DEVICE));
   static const char *cmd = "/usr/sbin/eos-repartition-mbr";
   g_autoptr(GSubprocessLauncher) launcher = NULL;

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -35,6 +35,7 @@
 #include <glib/gstdio.h>
 #include <glib/gi18n.h>
 #include <gio/gio.h>
+#include <gio/gunixfdlist.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/types.h>

--- a/gnome-image-installer/pages/install/gis-install-page.h
+++ b/gnome-image-installer/pages/install/gis-install-page.h
@@ -53,6 +53,9 @@ GType gis_install_page_get_type (void);
 
 void gis_prepare_install_page (GisDriver *driver);
 
+GQuark gis_install_error_quark (void);
+#define GIS_INSTALL_ERROR gis_install_error_quark()
+
 G_END_DECLS
 
 #endif /* __GIS_INSTALL_PAGE_H__ */

--- a/gnome-image-installer/util/Makefile.am
+++ b/gnome-image-installer/util/Makefile.am
@@ -8,6 +8,10 @@ libgiiutil_la_SOURCES = \
 	gpt_lzma.c gpt_lzma.h \
 	crc32.c crc32.h
 
-libgiiutil_la_CFLAGS = $(INITIAL_SETUP_CFLAGS) -I "$(srcdir)/.." -I "$(srcdir)/../../gnome-initial-setup"
+libgiiutil_la_CFLAGS = \
+	$(INITIAL_SETUP_CFLAGS) \
+	-I "$(srcdir)/.." \
+	-I "$(srcdir)/../../gnome-initial-setup" \
+	$(WARN_CFLAGS)
 libgiiutil_la_LIBADD = $(INITIAL_SETUP_LIBS) -lz
-libgiiutil_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined
+libgiiutil_la_LDFLAGS = -export_dynamic -avoid-version -module -no-undefined $(WARN_LDFLAGS)

--- a/gnome-image-installer/util/gis-store.c
+++ b/gnome-image-installer/util/gis-store.c
@@ -27,7 +27,7 @@
 #include "gis-store.h"
 
 static GObject *_objects[GIS_STORE_N_OBJECTS];
-static gint64 _size = 0;
+static guint64 _size = 0;
 static gint64 _image_size = 0;
 static gchar *_name = NULL;
 static gchar *_drive = NULL;
@@ -67,7 +67,7 @@ guint64 gis_store_get_required_size(void)
   return _size;
 }
 
-void gis_store_set_required_size(gint64 size)
+void gis_store_set_required_size(guint64 size)
 {
   _size = size;
 }

--- a/gnome-image-installer/util/gis-store.c
+++ b/gnome-image-installer/util/gis-store.c
@@ -62,7 +62,7 @@ void gis_store_clear_object(gint key)
   _objects[key] = NULL;
 }
 
-gint64 gis_store_get_required_size()
+guint64 gis_store_get_required_size(void)
 {
   return _size;
 }
@@ -82,7 +82,7 @@ void gis_store_set_image_size (gint64 size)
   _image_size = size;
 }
 
-gchar *gis_store_get_image_name()
+gchar *gis_store_get_image_name(void)
 {
   return _name;
 }
@@ -93,13 +93,13 @@ void gis_store_set_image_name(gchar *name)
   _name = g_strdup (name);
 }
 
-void gis_store_clear_image_name()
+void gis_store_clear_image_name(void)
 {
   g_free (_name);
   _name = NULL;
 }
 
-const gchar *gis_store_get_image_drive()
+const gchar *gis_store_get_image_drive(void)
 {
   return _drive;
 }
@@ -121,7 +121,7 @@ void gis_store_set_image_signature (const gchar *signature)
   _signature = g_strdup (signature);
 }
 
-GError *gis_store_get_error()
+GError *gis_store_get_error(void)
 {
   return _error;
 }
@@ -132,27 +132,27 @@ void gis_store_set_error(GError *error)
   _error = g_error_copy (error);
 }
 
-void gis_store_clear_error()
+void gis_store_clear_error(void)
 {
   g_clear_error (&_error);
 }
 
-void gis_store_enter_unattended()
+void gis_store_enter_unattended(void)
 {
   _unattended = TRUE;
 }
 
-gboolean gis_store_is_unattended()
+gboolean gis_store_is_unattended(void)
 {
   return _unattended;
 }
 
-void gis_store_enter_live_install()
+void gis_store_enter_live_install(void)
 {
   _live_install = TRUE;
 }
 
-gboolean gis_store_is_live_install()
+gboolean gis_store_is_live_install(void)
 {
   return _live_install;
 }
@@ -162,7 +162,7 @@ void gis_store_set_key_file(GKeyFile *keys)
   _keys = keys;
 }
 
-GKeyFile *gis_store_get_key_file()
+GKeyFile *gis_store_get_key_file(void)
 {
   return _keys;
 }

--- a/gnome-image-installer/util/gis-store.h
+++ b/gnome-image-installer/util/gis-store.h
@@ -40,34 +40,34 @@ GObject *gis_store_get_object(gint key);
 void gis_store_set_object(gint key, GObject *obj);
 void gis_store_clear_object(gint key);
 
-gint64 gis_store_get_required_size();
+guint64 gis_store_get_required_size(void);
 void gis_store_set_required_size(gint64 size);
 
 gint64 gis_store_get_image_size (void);
 void gis_store_set_image_size (gint64 size);
 
-gchar *gis_store_get_image_name();
+gchar *gis_store_get_image_name(void);
 void gis_store_set_image_name(gchar *name);
-void gis_store_clear_image_name();
+void gis_store_clear_image_name(void);
 
-const gchar *gis_store_get_image_drive();
+const gchar *gis_store_get_image_drive(void);
 void gis_store_set_image_drive(const gchar *drive);
 
 const gchar *gis_store_get_image_signature(void);
 void gis_store_set_image_signature(const gchar *signature);
 
-GError *gis_store_get_error();
+GError *gis_store_get_error(void);
 void gis_store_set_error(GError *error);
-void gis_store_clear_error();
+void gis_store_clear_error(void);
 
-void gis_store_enter_unattended();
-gboolean gis_store_is_unattended();
+void gis_store_enter_unattended(void);
+gboolean gis_store_is_unattended(void);
 
-void gis_store_enter_live_install();
-gboolean gis_store_is_live_install();
+void gis_store_enter_live_install(void);
+gboolean gis_store_is_live_install(void);
 
 void gis_store_set_key_file(GKeyFile *keys);
-GKeyFile *gis_store_get_key_file();
+GKeyFile *gis_store_get_key_file(void);
 
 G_END_DECLS
 

--- a/gnome-image-installer/util/gis-store.h
+++ b/gnome-image-installer/util/gis-store.h
@@ -41,7 +41,7 @@ void gis_store_set_object(gint key, GObject *obj);
 void gis_store_clear_object(gint key);
 
 guint64 gis_store_get_required_size(void);
-void gis_store_set_required_size(gint64 size);
+void gis_store_set_required_size(guint64 size);
 
 gint64 gis_store_get_image_size (void);
 void gis_store_set_image_size (gint64 size);

--- a/gnome-image-installer/util/gpt_lzma.c
+++ b/gnome-image-installer/util/gpt_lzma.c
@@ -1,7 +1,7 @@
 #include "gpt_lzma.h"
 
 // taken from the lzma documentation
-int init_decoder(lzma_stream *strm)
+static int init_decoder(lzma_stream *strm)
 {
 	// Initialize a .xz decoder. The decoder supports a memory usage limit
 	// and a set of flags.

--- a/gnome-initial-setup/gis-page.c
+++ b/gnome-initial-setup/gis-page.c
@@ -248,7 +248,7 @@ gis_page_get_title (GisPage *page)
 }
 
 void
-gis_page_set_title (GisPage *page, char *title)
+gis_page_set_title (GisPage *page, const char *title)
 {
   GisPagePrivate *priv = gis_page_get_instance_private (page);
   g_clear_pointer (&priv->title, g_free);

--- a/gnome-initial-setup/gis-page.h
+++ b/gnome-initial-setup/gis-page.h
@@ -59,7 +59,7 @@ struct _GisPageClass
   gboolean hide_forward_button;
   gboolean hide_backward_button;
   gboolean hide_window_controls;
-  char *page_id;
+  const char *page_id;
 
   GtkBuilder * (*get_builder) (GisPage *page);
   void         (*locale_changed) (GisPage *page);

--- a/gnome-initial-setup/gis-page.h
+++ b/gnome-initial-setup/gis-page.h
@@ -73,7 +73,7 @@ struct _GisPageClass
 GType gis_page_get_type (void);
 
 char *       gis_page_get_title (GisPage *page);
-void         gis_page_set_title (GisPage *page, char *title);
+void         gis_page_set_title (GisPage *page, const char *title);
 const char *       gis_page_get_forward_text (GisPage *page);
 void         gis_page_set_forward_text (GisPage *page, const char *text);
 gboolean     gis_page_get_complete (GisPage *page);


### PR DESCRIPTION
This covers `gnome-image-installer/`. Some code from `gnome-initial-setup/` is used but I'd rather fix those in upstream g-i-s and pull the changes back down. In a few places there were bugs there exposed by warnings in the installer-specific code, so I've fixed those as needed.

https://phabricator.endlessm.com/T15159