### PR TITLE
configure.ac: call AX_IS_RELEASE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,8 @@
 AC_INIT([eos-installer],[3.10.1.1])
 AC_CONFIG_MACRO_DIR([m4])
 
+AX_IS_RELEASE([git-directory])
+
 AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign tar-ustar])
 AM_SILENT_RULES([yes])
 


### PR DESCRIPTION
The result of this macro is used by AX_COMPILER_FLAGS to decide whether
warnings should be promoted to errors. When building from a Git repo,
warnings are fatal; when building in OBS, they are not.

See https://www.gnu.org/software/autoconf-archive/ax_is_release.html
and https://www.gnu.org/software/autoconf-archive/ax_compiler_flags.html
for more details.

In particular, this "fixes" (by ignoring the problem) a build failure on
ARM caused by GObject having 32-bit alignment, but GduXzDecompressor
having 64-bit alignment.

https://phabricator.endlessm.com/T15159