### PR TITLE
diskimage: add special-case for sea image

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -127,6 +127,28 @@ gis_diskimage_page_selection_changed(GtkWidget *combo, GisPage *page)
     }
 }
 
+static gchar *
+get_locale_name (const gchar *locale)
+{
+  /* This calls gnome_parse_locale(), which warns on malformed locales.
+  */
+  gchar *language = gnome_get_language_from_locale (locale, NULL);
+
+  if (language != NULL)
+    {
+      /* TODO: what is this stupid grumblegrumble... */
+      if (g_strrstr (language, "[") != NULL)
+        {
+          gchar **split = g_strsplit (language, " [", 0);
+          g_free (language);
+          language = g_strdup (split[0]);
+          g_strfreev (split);
+        }
+    }
+
+  return language;
+}
+
 static const gchar *
 lookup_personality (const gchar *personality)
 {
@@ -210,9 +232,7 @@ static gchar *get_display_name(const gchar *fullname)
       known_personality = lookup_personality (personality);
       if (known_personality == NULL)
         {
-          /* This calls gnome_parse_locale(), which warns on malformed locales.
-           */
-          language = gnome_get_language_from_locale (personality, NULL);
+          language = get_locale_name (personality);
           if (language == NULL)
             {
               known_personality = personality;
@@ -225,15 +245,6 @@ static gchar *get_display_name(const gchar *fullname)
         }
       else
         {
-          /* TODO: what is this stupid grumblegrumble... */
-          if (g_strrstr (language, "[") != NULL)
-            {
-              gchar **split = g_strsplit (language, " [", 0);
-              g_free (language);
-              language = g_strdup (split[0]);
-              g_strfreev (split);
-            }
-
           g_free (personality);
           personality = g_strdup (_("Full"));
 

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -336,6 +336,32 @@ file_exists (
   return FALSE;
 }
 
+/**
+ * Returns: the first of @a or @b which exists; or %NULL with a combined error
+ * if neither does.
+ */
+static gchar *
+first_existing (
+    gchar *a,
+    gchar *b,
+    GError **error)
+{
+  GError *error2 = NULL;
+
+  if (file_exists (a, &error2))
+    return a;
+
+  if (file_exists (b, error))
+    {
+      g_clear_error (&error2);
+      return b;
+    }
+
+  g_prefix_error (error, "%s; ", error2->message);
+  g_clear_error (&error2);
+  return NULL;
+}
+
 /* live USB sticks have an unpacked disk image named endless.img, which for
  * various reasons is invisible in directory listings. We can determine the
  * name that the image "should" have by reading /endless/live, and find the
@@ -358,17 +384,13 @@ gis_diskimage_page_add_live_image (
   g_autofree gchar *live_flag_contents = NULL;
   g_autofree gchar *live_sig_basename = NULL;
   g_autofree gchar *live_sig = NULL;
-  gchar *endless_path = NULL;
+  gchar *endless_path; /* either endless_img_path or endless_squash_path */
 
-  if (file_exists (endless_img_path, error))
-    endless_path = endless_img_path;
-  else if (file_exists (endless_squash_path, error))
-    endless_path = endless_squash_path;
-  else
+  endless_path = first_existing (endless_img_path, endless_squash_path, error);
+  if (endless_path == NULL)
     return FALSE;
 
-  if (!g_file_get_contents (live_flag_path, &live_flag_contents, NULL,
-        error))
+  if (!g_file_get_contents (live_flag_path, &live_flag_contents, NULL, error))
     {
       g_prefix_error (error, "Couldn't read %s: ", live_flag_path);
       return FALSE;
@@ -398,7 +420,7 @@ gis_diskimage_page_add_live_image (
     {
       add_image (store, endless_path, live_device_path, live_sig);
     }
-  else if (file_exists (endless_img_path, error))
+  else if (endless_path == endless_img_path)
     {
       g_print ("can't find image device %s; will use %s directly\n",
                live_device_path, endless_img_path);
@@ -406,8 +428,10 @@ gis_diskimage_page_add_live_image (
     }
   else
     {
-      g_print ("cannot find neither %s nor %s\n",
-               live_device_path, endless_path);
+      // TODO: mount the squashfs image and read endless.img from within it?
+      g_set_error (error, GIS_IMAGE_ERROR, 0,
+          "can't find image device %s; and can't use %s directly\n",
+          live_device_path, endless_path);
       return FALSE;
     }
 


### PR DESCRIPTION
It would be nice if we called the image just _("Thai") when the current locale is a Thai locale (say) but this is actually marginally more involved than it sounds. Rather than being defined in util or something, cc_common_language_get_current_language() is defined in two separate copies of cc-common-language.[ch]! Build system changes needed for that.

https://phabricator.endlessm.com/T15541