### PR TITLE
install: fix verify progress on ISOs

### DIFF
--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -596,7 +596,7 @@ gis_install_page_gpg_progress (GIOChannel *source, GIOCondition cond, GisPage *p
          * considers the size to be 0.
          */
         if (full == 0)
-          full = gis_store_get_image_size ();
+          full = gis_store_get_required_size ();
 
         frac = curr/full;
         gtk_progress_bar_set_fraction (OBJ (GtkProgressBar*, "install_progress"), frac);


### PR DESCRIPTION
When booted from an uncompressed image, gis_store_get_image_size() and
gis_store_get_required_size() are equal. When booted from a SquashFS
image on an ISO, they are not: get_image_size() returns the size of the
SquashFS image, and get_required_size() returns the size of the
uncompressed image within. (This is consistent with what is shown in the
UI: the image-selector dropdown menu uses the compressed size of the
image, and the target page uses the uncompressed size.)

When gpg cannot determine the total size of the file being verified, it
is because it is reading from /dev/mapper/endless-image. So we are
always verifying the decompressed image, so should use the uncompressed
size as the total.

Without this change, when verifying a SquashFS'd image, the progress bar
exceeds 100%.

https://phabricator.endlessm.com/T15786