### PR TITLE
Use decimal gigabytes

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -352,7 +352,7 @@ add_image (
       if (displayname != NULL)
         {
           goffset size_bytes = g_file_info_get_size (fi);
-          size = g_strdup_printf ("%.02f GB", (float)size_bytes/1024.0/1024.0/1024.0);
+          size = g_format_size_full (size_bytes, G_FORMAT_SIZE_DEFAULT);
 
           gtk_list_store_append (store, &i);
           gtk_list_store_set (store, &i,

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -120,11 +120,14 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
       g_object_unref(block);
       if (udisks_drive_get_size(drive) < gis_store_get_required_size())
         {
-          gchar *msg = g_strdup_printf (
-            _("The location you have chosen is too small - you need more space to reformat with %s (%.02f GB)"),
-            gis_store_get_image_name(), gis_store_get_required_size()/1024.0/1024.0/1024.0);
+          g_autofree gchar *size = g_format_size_full (
+              gis_store_get_required_size (),
+              G_FORMAT_SIZE_LONG_FORMAT);
+          g_autofree gchar *msg = g_strdup_printf (
+              _("The location you have chosen is too small: you need %s to reformat with %s."),
+              size,
+              gis_store_get_image_name());
           gtk_label_set_text (OBJ (GtkLabel*, "too_small_label"), msg);
-          g_free (msg);
           gtk_widget_hide (WID ("confirm_box"));
           gtk_widget_show (WID ("error_box"));
           return;
@@ -329,8 +332,8 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       targetname = g_strdup_printf("%s %s",
                                    udisks_drive_get_vendor(drive),
                                    udisks_drive_get_model(drive));
-      targetsize = g_strdup_printf("%.02f GB",
-                                   udisks_drive_get_size(drive)/1024.0/1024.0/1024.0);
+      targetsize = g_format_size_full (udisks_drive_get_size(drive),
+                                       G_FORMAT_SIZE_DEFAULT);
       gtk_list_store_append(store, &i);
       gtk_list_store_set(store, &i, 0, targetname, 1, targetsize,
                                     2, G_OBJECT(block), 3, has_data_partitions, -1);

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
@@ -206,7 +206,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_left">12</property>
-                <property name="label" translatable="yes">The location you have chosen is too small - you need more space to reformat with %s (%.02f GB)</property>
+                <property name="label" translatable="yes">The location you have chosen is too small: you need %s to reformat with %s.</property>
                 <property name="wrap">True</property>
                 <property name="wrap_mode">word-char</property>
                 <property name="max_width_chars">50</property>


### PR DESCRIPTION
This matches what Nautilus and other GNOME applications show for the
size of a file or storage device, by virtue of using the same function.
This also means "GB" is localized into the interface language.

In the error case when the selected drive is too small, we show the size
of the image file in bytes, to be absolutely clear how much space is
needed.

https://phabricator.endlessm.com/T12718