### PR TITLE
assistant: don't enable controls in FBE

### DIFF
--- a/gnome-initial-setup/gis-assistant.c
+++ b/gnome-initial-setup/gis-assistant.c
@@ -59,6 +59,8 @@ struct _GisAssistantPrivate
 
   GList *pages;
   GisPage *current_page;
+
+  gboolean enable_controls;
 };
 typedef struct _GisAssistantPrivate GisAssistantPrivate;
 
@@ -237,6 +239,7 @@ update_navigation_buttons (GisAssistant *assistant)
   is_last_page = (page_priv->link->next == NULL);
 
   gtk_header_bar_set_show_close_button (GTK_HEADER_BAR (priv->titlebar),
+                                        priv->enable_controls &&
                                         !gis_page_get_hide_window_controls (page));
 
   if (is_last_page)
@@ -455,6 +458,13 @@ gis_assistant_save_data (GisAssistant *assistant)
 
   for (l = priv->pages; l != NULL; l = l->next)
     gis_page_save_data (l->data);
+}
+
+void
+gis_assistant_enable_controls (GisAssistant *assistant)
+{
+  GisAssistantPrivate *priv = gis_assistant_get_instance_private (assistant);
+  priv->enable_controls = TRUE;
 }
 
 static void

--- a/gnome-initial-setup/gis-assistant.h
+++ b/gnome-initial-setup/gis-assistant.h
@@ -70,6 +70,7 @@ GtkWidget *gis_assistant_get_titlebar     (GisAssistant *assistant);
 
 void      gis_assistant_locale_changed    (GisAssistant *assistant);
 void      gis_assistant_save_data         (GisAssistant *assistant);
+void      gis_assistant_enable_controls   (GisAssistant *assistant);
 
 G_END_DECLS
 

--- a/gnome-initial-setup/gis-driver.c
+++ b/gnome-initial-setup/gis-driver.c
@@ -142,7 +142,7 @@ prepare_main_window (GisDriver *driver)
   titlebar = gis_assistant_get_titlebar (priv->assistant);
   if (priv->mode == GIS_DRIVER_MODE_EXISTING_USER)
     {
-      gtk_header_bar_set_show_close_button (GTK_HEADER_BAR (titlebar), TRUE);
+      gis_assistant_enable_controls (priv->assistant);
       gtk_window_set_deletable (priv->main_window, TRUE);
     }
   gtk_window_set_titlebar (priv->main_window, titlebar);


### PR DESCRIPTION
`gtk_header_bar_set_show_close_button()` is misleadingly-named: it controls whether any controls at all are shown. The default is `FALSE`.

Previously, we correctly only showed the actual close button when running under a user session: it's controlled by the combination of `gtk_header_bar_set_show_close_button()` and `gtk_window_set_deletable()`.  But by attempting to hide the close button (and other controls) on the install page -- for which `gis_page_get_hide_window_controls()` returns `TRUE` -- gis-assistant would show the minimize button on all other pages, even in FBE mode, overriding whatever gis-driver had configured.

To fix this, we push a global `enable_controls` flag from gis-driver into gis-assistant, and take this into account when updating the controls.

https://phabricator.endlessm.com/T14728