### PR TITLE
Update gnome-shell initial-setup mode definition

### DIFF
--- a/data/initial-setup.json
+++ b/data/initial-setup.json
@@ -3,6 +3,6 @@
     "components": ["networkAgent"],
     "panel": { "left": [],
                "center": [],
-               "right": ["a11yGreeter", "keyboard", "volume", "battery"]
+               "right": ["a11yGreeter", "keyboard", "aggregateMenu"]
     }
 }

--- a/gnome-image-installer/gnome-image-installer.c
+++ b/gnome-image-installer/gnome-image-installer.c
@@ -289,7 +289,11 @@ rebuild_pages_cb (GisDriver *driver)
   assistant = gis_driver_get_assistant (driver);
   current_page = gis_assistant_get_current_page (assistant);
 
-  page_data = page_table;
+  /* Omit welcome page entirely in live mode */
+  if (gis_store_is_live_install ())
+    page_data = page_table + 1;
+  else
+    page_data = page_table;
 
   if (current_page != NULL) {
     destroy_pages_after (assistant, current_page);
@@ -306,8 +310,8 @@ rebuild_pages_cb (GisDriver *driver)
 
   gis_assistant_locale_changed (assistant);
 
-  /* Skip welcome page in unattended and live install mode */
-  if (gis_store_is_unattended () || gis_store_is_live_install ())
+  /* Skip welcome page in unattended mode */
+  if (gis_store_is_unattended () && !gis_store_is_live_install ())
     gis_assistant_next_page (assistant);
 }
 


### PR DESCRIPTION
This patch is by @cosimoc, cherry-picked from https://github.com/endlessm/gnome-initial-setup/commit/6deff6883dea75f5114ee42a40b6e811602cabcc

I also threw in a patch to fix a pet peeve of mine: the Back button on the image selection page when running in live mode.

https://phabricator.endlessm.com/T17875