### PR TITLE
standalone: install gnome-shell initial-setup mode config

### DIFF
--- a/debian/eos-installer-standalone.install
+++ b/debian/eos-installer-standalone.install
@@ -1,3 +1,3 @@
-debian/tmp/usr/share/gnome-session/sessions/eos-installer.session
-debian/tmp/usr/share/gdm/greeter/applications/eos-setup-shell.desktop
 debian/tmp/lib/systemd/system/run-mount-eosimages.mount
+debian/tmp/usr/share/gdm/greeter/applications/eos-setup-shell.desktop
+debian/tmp/usr/share/gnome-session/sessions/eos-installer.session

--- a/debian/eos-installer-standalone.install
+++ b/debian/eos-installer-standalone.install
@@ -1,3 +1,4 @@
 debian/tmp/lib/systemd/system/run-mount-eosimages.mount
 debian/tmp/usr/share/gdm/greeter/applications/eos-setup-shell.desktop
 debian/tmp/usr/share/gnome-session/sessions/eos-installer.session
+debian/tmp/usr/share/gnome-shell/modes/initial-setup.json

--- a/debian/eos-installer.install
+++ b/debian/eos-installer.install
@@ -1,5 +1,5 @@
-debian/tmp/usr/share/locale/*
-debian/tmp/usr/share/icons/*
 debian/tmp/usr/lib/eos-installer/*
 debian/tmp/usr/share/gdm/greeter/applications/eos-installer.desktop
+debian/tmp/usr/share/icons/*
+debian/tmp/usr/share/locale/*
 debian/tmp/usr/share/polkit-1/rules.d/20-eos-installer.rules


### PR DESCRIPTION
Endless OS 3.1 (and earlier) included an older fork of GNOME Shell that defined the initial-setup mode internally. The newer version of the Shell in 3.2 removes this internal definition in favour of loading the definition from a config file. The gnome-initial-setup package installs this file, but the eos-installer-standalone package (which conflicts with it) does not.

https://phabricator.endlessm.com/T17875