### PR TITLE
assistant: ensure page content fills all vertical space

### DIFF
--- a/gnome-initial-setup/gis-assistant.ui
+++ b/gnome-initial-setup/gis-assistant.ui
@@ -50,6 +50,8 @@
             <property name="transition-type">slide-left-right</property>
             <property name="hhomogeneous">False</property>
             <property name="vhomogeneous">False</property>
+            <property name="vexpand">True</property>
+            <property name="vexpand-set">True</property>
             <signal name="notify::visible-child" handler="visible_child_changed" object="GisAssistant" swapped="yes"/>
           </object>
         </child>


### PR DESCRIPTION
Before 0e3b6f3 the language page forced the GtkStack to fill all
available vertical space, but when I rushed in a patch to remove the
language page on live boots (the normal FBE will have been shown to let
you pick the language already), this was no longer true. I do not know
why I didn't spot this in testing.

https://phabricator.endlessm.com/T18063