### PR TITLE
diskimage: recognise eosdvd product

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -257,6 +257,15 @@ static gchar *get_display_name(const gchar *fullname)
            */
           product = g_strdup (_("Endless OS (OEM)"));
         }
+      else if (g_str_equal (product, "eosdvd"))
+        {
+          g_free (product);
+          /* Translators: this is the DVD-sized edition of Endless OS. Please
+           * only translate this if "DVD" is not widely understood in your
+           * language.
+           */
+          product = g_strdup (_("Endless OS (DVD)"));
+        }
       else if (g_str_equal (product, "fnde"))
         {
           g_free (product);

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -250,6 +250,11 @@ static gchar *get_display_name(const gchar *fullname)
       else if (g_str_equal (product, "eosoem"))
         {
           g_free (product);
+          /* Translators: this is the edition of Endless OS pre-installed by
+           * Original Equipment Manufacturers. If there is not a
+           * widely-understood short translation of "OEM" in your language,
+           * please do not translate this.
+           */
           product = g_strdup (_("Endless OS (OEM)"));
         }
       else if (g_str_equal (product, "fnde"))


### PR DESCRIPTION
Without this change, "dvd" will be shown to the user in place of "Endless OS (DVD)".

https://phabricator.endlessm.com/T18626