### PR TITLE
Fix stray printf string when no appropriate targets are available

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -676,10 +676,28 @@ gis_diskimage_page_mount (GisPage *page)
   gis_assistant_next_page (gis_driver_get_assistant (page->driver));
 }
 
+static gboolean
+gis_diskimage_page_shown_idle_cb (gpointer user_data)
+{
+  GisPage *page = GIS_PAGE (user_data);
+
+  gis_diskimage_page_mount (page);
+
+  return G_SOURCE_REMOVE;
+}
+
 static void
 gis_diskimage_page_shown (GisPage *page)
 {
-  gis_diskimage_page_mount (page);
+  /* In most cases, this page is the first page shown.
+   * gis_diskimage_page_mount() can, in several situations, call
+   * gis_assistant_next_page() synchronously. But when the page is first shown,
+   * the list of pages is not fully initialized in the driver.
+   *
+   * So, defer initializing the page.
+   */
+  g_idle_add_full (G_PRIORITY_DEFAULT, gis_diskimage_page_shown_idle_cb,
+                   g_object_ref (page), g_object_unref);
 }
 
 static void

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -679,8 +679,6 @@ gis_diskimage_page_mount (GisPage *page)
 static void
 gis_diskimage_page_shown (GisPage *page)
 {
-  gis_driver_save_data (GIS_PAGE (page)->driver);
-
   gis_diskimage_page_mount (page);
 }
 

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -556,7 +556,6 @@ gis_diskimage_page_populate_model(GisPage *page, gchar *path)
       !gis_diskimage_page_add_live_image (store, path, ufile, &error))
     {
       g_print ("finding live image failed: %s\n", error->message);
-      g_clear_error (&error);
     }
 
   if (gtk_tree_model_get_iter_first (GTK_TREE_MODEL (store), &iter))
@@ -566,7 +565,8 @@ gis_diskimage_page_populate_model(GisPage *page, gchar *path)
     }
   else
     {
-      error = g_error_new (GIS_IMAGE_ERROR, 0, _("No suitable images were found."));
+      if (error == NULL)
+        error = g_error_new (GIS_IMAGE_ERROR, 0, _("No suitable images were found."));
       gis_store_set_error (error);
       g_clear_error (&error);
       gis_assistant_next_page (gis_driver_get_assistant (page->driver));

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -351,11 +351,8 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       gtk_combo_box_set_active_iter (combo, &i);
     }
 
-  if (priv->has_valid_disks)
-    {
-      gtk_widget_set_visible (WID ("suitable_disks_label"), FALSE);
-    }
-  else
+  gtk_widget_set_visible (WID ("suitable_disks_box"), !priv->has_valid_disks);
+  if (!priv->has_valid_disks)
     {
       GisAssistant *assistant = gis_driver_get_assistant (page->driver);
       GList *pages = g_list_last (gis_assistant_get_all_pages (assistant));
@@ -363,7 +360,6 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       GError *error = g_error_new_literal (GIS_DISK_ERROR, 0, text);
 
       pages = g_list_remove (pages, pages->prev->data);
-      gtk_widget_set_visible (WID ("suitable_disks_label"), TRUE);
       gis_page_set_forward_text (page, _("Finish"));
       gis_assistant_locale_changed (assistant);
       gis_store_set_error (error);

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -350,6 +350,13 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       GtkComboBox *combo = OBJ (GtkComboBox*, "diskcombo");
       gtk_combo_box_set_active_iter (combo, &i);
     }
+  else
+    {
+      gtk_widget_hide (WID ("confirm_box"));
+      gtk_widget_hide (WID ("partitionbutton"));
+      gtk_widget_hide (WID ("too_small_box"));
+      gtk_widget_show (WID ("error_box"));
+    }
 
   gtk_widget_set_visible (WID ("suitable_disks_box"), !priv->has_valid_disks);
   if (!priv->has_valid_disks)

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -381,8 +381,6 @@ gis_disktarget_page_shown (GisPage *page)
   GisDiskTargetPage *disktarget = GIS_DISK_TARGET_PAGE (page);
   GisDiskTargetPagePrivate *priv = gis_disktarget_page_get_instance_private (disktarget);
 
-  gis_driver_save_data (GIS_PAGE (page)->driver);
-
   if (gis_store_get_error() != NULL)
     {
       gis_assistant_next_page (gis_driver_get_assistant (page->driver));

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -100,7 +100,6 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
   GtkTreeModel *model = gtk_combo_box_get_model (GTK_COMBO_BOX (combo));
   gboolean has_data_partitions = FALSE;
 
-  gis_page_set_complete (GIS_PAGE (disktarget), FALSE);
   gtk_widget_hide (WID ("partitionbutton"));
 
   if (!gtk_combo_box_get_active_iter (GTK_COMBO_BOX (combo), &i))
@@ -130,6 +129,7 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
           gtk_label_set_text (OBJ (GtkLabel*, "too_small_label"), msg);
           gtk_widget_hide (WID ("confirm_box"));
           gtk_widget_show (WID ("error_box"));
+          check_can_continue (disktarget);
           return;
         }
     }

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
@@ -185,7 +185,7 @@
         <property name="spacing">32</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkBox" id="box2">
+          <object class="GtkBox" id="too_small_box">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_left">46</property>

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
@@ -102,23 +102,23 @@
       </packing>
     </child>
     <child>
+      <object class="GtkSeparator" id="separator2">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_top">32</property>
+        <property name="margin_bottom">32</property>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">4</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkBox" id="confirm_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkSeparator" id="separator2">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">32</property>
-            <property name="margin_bottom">32</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkCheckButton" id="confirmbutton">
             <property name="visible">True</property>
@@ -140,7 +140,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
@@ -167,21 +167,20 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>
       <packing>
         <property name="expand">False</property>
         <property name="fill">True</property>
-        <property name="position">4</property>
+        <property name="position">5</property>
       </packing>
     </child>
     <child>
       <object class="GtkBox" id="error_box">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_top">32</property>
         <property name="spacing">32</property>
         <property name="orientation">vertical</property>
         <child>
@@ -278,7 +277,7 @@
       <packing>
         <property name="expand">False</property>
         <property name="fill">False</property>
-        <property name="position">5</property>
+        <property name="position">6</property>
       </packing>
     </child>
   </object>

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.ui
@@ -182,6 +182,7 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="margin_top">32</property>
+        <property name="spacing">32</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="box2">
@@ -229,14 +230,43 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="suitable_disks_label">
+          <object class="GtkBox" id="suitable_disks_box">
+            <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_left">72</property>
-            <property name="margin_top">16</property>
-            <property name="label" translatable="yes">No suitable disks found.</property>
-            <property name="wrap">True</property>
-            <property name="max_width_chars">50</property>
-            <property name="xalign">0</property>
+            <property name="margin_left">46</property>
+            <child>
+              <object class="GtkImage" id="image2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_right">12</property>
+                <property name="stock">gtk-dialog-error</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="suitable_disks_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_left">12</property>
+                <property name="label" translatable="yes">No suitable disks found.</property>
+                <property name="wrap">True</property>
+                <property name="wrap_mode">word-char</property>
+                <property name="max_width_chars">50</property>
+                <property name="xalign">0</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -678,8 +678,6 @@ gis_install_page_shown (GisPage *page)
   gtk_label_set_text (OBJ (GtkLabel*, "install_label"), msg);
   g_free (msg);
 
-  gis_driver_save_data (GIS_PAGE (page)->driver);
-
   priv->client = UDISKS_CLIENT (gis_store_get_object (GIS_STORE_UDISKS_CLIENT));
 
   if (gis_store_get_error () != NULL)


### PR DESCRIPTION
Also: many other related layout fixes, and some better error handling.

No suitable devices at all:

![screenshot from 2017-09-25 17-18-16](https://user-images.githubusercontent.com/86760/30819098-936bc2ca-a215-11e7-936f-3d551185b7e8.png)

All devices are too small:

![screenshot from 2017-09-25 17-19-54](https://user-images.githubusercontent.com/86760/30819238-05fde61a-a216-11e7-9717-f002e43d83b6.png)

Selected device is too small, but at least one is okay:

![screenshot from 2017-09-25 17-20-48](https://user-images.githubusercontent.com/86760/30819249-0bbd494c-a216-11e7-8a0c-9e81ed886224.png)

https://phabricator.endlessm.com/T15306