### PR TITLE
Verify endless.squash directly

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -56,13 +56,25 @@ G_DEFINE_TYPE_WITH_PRIVATE (GisDiskImagePage, gis_diskimage_page, GIS_TYPE_PAGE)
 
 G_DEFINE_QUARK(image-error, gis_image_error);
 
-/* A device-mapped copy of endless.img used in image boots.
+/* A device-mapped copy of endless.img used in image boots from exFAT.
  * We prefer to use this to endless.img from the filesystem for two reasons:
- * - 'error' is mapped over the sectors of the drive which correspond to the
+ * - zeros are mapped over the sectors of the drive which correspond to the
  *   image, so we can't read it from the filesystem
  * - reading from the filesystem (via fuse) comes with a big overhead
+ * Even if we are booted from ISO (using a regular loop device), and/or
+ * from endless.squash (so the endless.img within can be mapped to a regular
+ * loop device), the boot scripts always arrange for this device to exist, and
+ * there should be no overhead in unnecessarily using it.
  */
 static const gchar * const live_device_path = "/dev/mapper/endless-image";
+
+/* A device-mapped copy of endless.squash used in image boots from exFAT.
+ * Although in this case we will read from live_device_path when writing to
+ * disk, we prefer to read the compressed file while verifying to avoid
+ * incurring the decompression overhead twice, in addition to the two reasons
+ * above.
+ */
+static const gchar * const squashfs_device_path = "/dev/mapper/endless-image-squashfs";
 
 /* Deliberately out-of-order so that sorting is exercised in English */
 static const gchar * const sea_locales[] = {
@@ -194,7 +206,7 @@ static gchar *get_display_name(const gchar *fullname)
   GMatchInfo *info;
   gchar *name = NULL;
 
-  reg = g_regex_new ("^.*/([^-]+)-([^-]+)-(?:[^-]+)-(?:[^.]+)\\.(?:[^.]+)\\.([^.]+)(?:\\.(disk\\d))?\\.img(?:\\.([gx]z|asc))$", 0, 0, NULL);
+  reg = g_regex_new ("^.*/([^-]+)-([^-]+)-(?:[^-]+)-(?:[^.]+)\\.(?:[^.]+)\\.([^.]+)(?:\\.(disk\\d))?\\.(?:img|squash)(?:\\.([gx]z|asc))$", 0, 0, NULL);
   g_regex_match (reg, fullname, 0, &info);
   if (g_match_info_matches (info))
     {
@@ -294,6 +306,7 @@ add_image (
     GtkListStore *store,
     const gchar  *image,
     const gchar  *image_device,
+    const gchar  *verify_path,
     const gchar  *signature)
 {
   GError *error = NULL;
@@ -344,18 +357,27 @@ add_image (
           g_autofree gchar *size = NULL;
           g_autoptr(GFile) image_file = NULL;
           g_autoptr(GFile) signature_file = NULL;
+          g_autoptr(GFile) verify_file = NULL;
           g_autoptr(GisImage) gis_image = NULL;
 
           size = g_format_size_full (size_bytes, G_FORMAT_SIZE_DEFAULT);
+
+          g_print ("Found image: %s (%s, image_device=%s, verify_path=%s, signature=%s)\n",
+              image, size, image_device, verify_path, signature);
 
           if (image_device != NULL)
             image_file = g_file_new_for_path (image_device);
           else
             image_file = g_object_ref (f);
 
+          if (verify_path != NULL)
+            verify_file = g_file_new_for_path (verify_path);
+          else
+            verify_file = g_object_ref (image_file);
+
           signature_file = g_file_new_for_path (signature);
-          gis_image = gis_image_new (displayname, image_file, signature_file,
-              size_bytes, required_size);
+          gis_image = gis_image_new (displayname, image_file, verify_file,
+              signature_file, size_bytes, required_size);
           gtk_list_store_insert_with_values (store, NULL, -1,
                                              IMAGE_NAME, displayname,
                                              IMAGE_SIZE, size,
@@ -384,37 +406,12 @@ file_exists (
   return FALSE;
 }
 
-/**
- * Returns: the first of @a or @b which exists; or %NULL with a combined error
- * if neither does.
- */
-static gchar *
-first_existing (
-    gchar *a,
-    gchar *b,
-    GError **error)
-{
-  GError *error2 = NULL;
-
-  if (file_exists (a, &error2))
-    return a;
-
-  if (file_exists (b, error))
-    {
-      g_clear_error (&error2);
-      return b;
-    }
-
-  g_prefix_error (error, "%s; ", error2->message);
-  g_clear_error (&error2);
-  return NULL;
-}
-
-/* live USB sticks have an unpacked disk image named endless.img, which for
- * various reasons is invisible in directory listings. We can determine the
- * name that the image "should" have by reading /endless/live, and find the
- * corresponding signature file.
- * For ISOs the disk image is called endless.squash.
+/* ISOs have a squashfs image named /endless/endless.squash, and live USB
+ * sticks have either this or an unpacked image named /endless/endless.img. For
+ * various reasons, these are sometimes invisible in exFAT directory listings.
+ *
+ * We can get the name that the image "should" have by reading /endless/live,
+ * and use this to find the image and corresponding signature file.
  */
 static gboolean
 gis_diskimage_page_add_live_image (
@@ -423,38 +420,54 @@ gis_diskimage_page_add_live_image (
     const gchar  *ufile,
     GError      **error)
 {
-  g_autofree gchar *endless_img_path = g_build_path (
-      "/", path, "endless", "endless.img", NULL);
-  g_autofree gchar *endless_squash_path = g_build_path (
-      "/", path, "endless", "endless.squash", NULL);
-  g_autofree gchar *live_flag_path = g_build_path (
-      "/", path, "endless", "live", NULL);
+  g_autofree gchar *live_flag_path = NULL;
   g_autofree gchar *live_flag_contents = NULL;
   g_autofree gchar *live_sig_basename = NULL;
   g_autofree gchar *live_sig = NULL;
-  gchar *endless_path; /* either endless_img_path or endless_squash_path */
+  const gchar *endless_basename = NULL;
+  g_autofree gchar *endless_path = NULL;
+  gboolean is_squashfs = FALSE;
+  const gchar *verify_path = NULL;
 
-  endless_path = first_existing (endless_img_path, endless_squash_path, error);
-  if (endless_path == NULL)
-    return FALSE;
-
+  live_flag_path = g_build_path ("/", path, "endless", "live", NULL);
   if (!g_file_get_contents (live_flag_path, &live_flag_contents, NULL, error))
     {
       g_prefix_error (error, "Couldn't read %s: ", live_flag_path);
       return FALSE;
     }
 
-  /* live_flag_contents contains the name that 'endless.img' would have had;
-   * so we should be able to find its signature at ${live_flag_contents}.asc
+  /* live_flag_contents contains the name that endless.img/endless.squash would have had;
+   * so we should be able to find the image at endless.<ext> and its signature
+   * at ${live_flag_contents}.asc
    */
   g_strstrip (live_flag_contents);
+
+  if (g_str_has_suffix (live_flag_contents, ".img"))
+    {
+      endless_basename = "endless.img";
+      is_squashfs = FALSE;
+    }
+  else if (g_str_has_suffix (live_flag_contents, ".squash"))
+    {
+      endless_basename = "endless.squash";
+      is_squashfs = TRUE;
+    }
+  else
+    {
+      g_set_error (error, GIS_IMAGE_ERROR, 0, "Unknown live image format '%s'",
+          live_flag_contents);
+      return FALSE;
+    }
+
+  endless_path = g_build_path ("/", path, "endless", endless_basename, NULL);
+  if (!file_exists (endless_path, error))
+    return FALSE;
+
   live_sig_basename = g_strdup_printf ("%s.%s", live_flag_contents, "asc");
   live_sig = g_build_path ("/", path, "endless", live_sig_basename, NULL);
 
   if (!file_exists (live_sig, error))
-    {
-      return FALSE;
-    }
+    return FALSE;
 
   if (ufile != NULL && g_strcmp0 (ufile, live_flag_contents) != 0)
     {
@@ -464,15 +477,21 @@ gis_diskimage_page_add_live_image (
       return FALSE;
     }
 
+  if (is_squashfs)
+    {
+      if (file_exists (squashfs_device_path, NULL))
+        verify_path = squashfs_device_path;
+      else
+        verify_path = endless_path;
+    }
+
   if (file_exists (live_device_path, NULL))
     {
-      add_image (store, endless_path, live_device_path, live_sig);
+      add_image (store, endless_path, live_device_path, verify_path, live_sig);
     }
-  else if (endless_path == endless_img_path)
+  else if (!is_squashfs)
     {
-      g_print ("can't find image device %s; will use %s directly\n",
-               live_device_path, endless_img_path);
-      add_image (store, endless_img_path, NULL, live_sig);
+      add_image (store, endless_path, NULL, NULL, live_sig);
     }
   else
     {
@@ -525,7 +544,7 @@ gis_diskimage_page_populate_model(GisPage *page, gchar *path)
       /* ufile is only set in the unattended case */
       if (ufile == NULL || g_str_equal (ufile, file))
         {
-          add_image (store, fullpath, NULL, signature);
+          add_image (store, fullpath, NULL, NULL, signature);
         }
     }
 

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.ui
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.ui
@@ -8,16 +8,10 @@
       <column type="gchararray"/>
       <!-- column-name image_size -->
       <column type="gchararray"/>
-      <!-- column-name image_size_bytes -->
-      <column type="gint64"/>
-      <!-- column-name image_file -->
-      <column type="gchararray"/>
-      <!-- column-name image_signature -->
-      <column type="gchararray"/>
       <!-- column-name align -->
       <column type="PangoAlignment"/>
-      <!-- column-name required_size -->
-      <column type="guint64"/>
+      <!-- column-name image -->
+      <column type="GisImage"/>
     </columns>
   </object>
   <object class="GtkBox" id="diskimage-page">
@@ -130,7 +124,7 @@
                         <property name="xpad">24</property>
                       </object>
                       <attributes>
-                        <attribute name="alignment">5</attribute>
+                        <attribute name="alignment">2</attribute>
                         <attribute name="text">1</attribute>
                       </attributes>
                     </child>

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -57,6 +57,7 @@ check_can_continue(GisDiskTargetPage *page)
   GisDiskTargetPagePrivate *priv = gis_disktarget_page_get_instance_private (page);
   GtkToggleButton *button = OBJ (GtkToggleButton*, "confirmbutton");
   GtkToggleButton *pbutton = OBJ (GtkToggleButton*, "partitionbutton");
+  GisImage *image = gis_store_get_selected_image ();
   UDisksBlock *block = UDISKS_BLOCK (gis_store_get_object (GIS_STORE_BLOCK_DEVICE));
   UDisksDrive *drive = NULL;
 
@@ -72,7 +73,7 @@ check_can_continue(GisDiskTargetPage *page)
   if (drive == NULL)
     return;
 
-  if (udisks_drive_get_size(drive) < gis_store_get_required_size())
+  if (udisks_drive_get_size (drive) < image->uncompressed_size)
     return;
 
   if (!gtk_toggle_button_get_active (button))
@@ -114,18 +115,21 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
 
   if (block != NULL)
     {
+      GisImage *image = gis_store_get_selected_image ();
       UDisksDrive *drive = udisks_client_get_drive_for_block (priv->client, UDISKS_BLOCK(block));
       gis_store_set_object (GIS_STORE_BLOCK_DEVICE, block);
       g_object_unref(block);
-      if (udisks_drive_get_size(drive) < gis_store_get_required_size())
+
+      if (udisks_drive_get_size (drive) < image->uncompressed_size)
         {
           g_autofree gchar *size = g_format_size_full (
-              gis_store_get_required_size (),
+              image->uncompressed_size,
               G_FORMAT_SIZE_LONG_FORMAT);
           g_autofree gchar *msg = g_strdup_printf (
               _("The location you have chosen is too small: you need %s to reformat with %s."),
               size,
-              gis_store_get_image_name());
+              image->name);
+
           gtk_label_set_text (OBJ (GtkLabel*, "too_small_label"), msg);
           gtk_widget_hide (WID ("confirm_box"));
           gtk_widget_show (WID ("error_box"));
@@ -269,6 +273,7 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
   UDisksDrive *root = NULL;
   UDisksDrive *image_drive = UDISKS_DRIVE (gis_store_get_object (GIS_STORE_IMAGE_DRIVE));
   const gchar *image_drive_path = NULL;
+  GisImage *image = gis_store_get_selected_image ();
 
   if (image_drive != NULL)
     image_drive_path = g_dbus_proxy_get_object_path (G_DBUS_PROXY (image_drive));
@@ -325,7 +330,7 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
                "it hosts the image partition");
 #undef skip_if
 
-      if (udisks_drive_get_size(drive) >= gis_store_get_required_size())
+      if (udisks_drive_get_size(drive) >= image->uncompressed_size)
         {
           priv->has_valid_disks = TRUE;
         }

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -292,7 +292,8 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
   root = gis_disktarget_page_get_root_drive (client);
   for (l = objects; l != NULL; l = l->next)
     {
-      gchar *targetname, *targetsize;
+      g_autofree gchar *targetname = NULL;
+      g_autofree gchar *targetsize = NULL;
       UDisksObject *object = UDISKS_OBJECT(l->data);
       const gchar *object_path;
       UDisksDrive *drive = udisks_object_peek_drive(object);
@@ -342,11 +343,13 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
                                    udisks_drive_get_model(drive));
       targetsize = g_format_size_full (udisks_drive_get_size(drive),
                                        G_FORMAT_SIZE_DEFAULT);
-      gtk_list_store_append(store, &i);
-      gtk_list_store_set(store, &i, 0, targetname, 1, targetsize,
-                                    2, G_OBJECT(block), 3, has_data_partitions, -1);
-      g_free(targetname);
-      g_free(targetsize);
+
+      gtk_list_store_insert_with_values (store, NULL, -1,
+                                         0, targetname,
+                                         1, targetsize,
+                                         2, G_OBJECT (block),
+                                         3, has_data_partitions,
+                                         -1);
     }
   g_clear_object (&root);
 

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -46,10 +46,9 @@
 
 struct _GisInstallPagePrivate {
   GMutex copy_mutex;
-  GFile *image;
+  GisImage *image;
   GObject *decompressor;
   GInputStream *decompressed;
-  gint64 decompressed_size;
   gint drive_fd;
   gint64 bytes_written;
   GThread *copythread;
@@ -134,13 +133,11 @@ gis_install_page_prepare_read (GisPage *page, GError **error)
   gchar *basename = NULL;
   GError *e = NULL;
 
-  priv->decompressed_size = gis_store_get_required_size();
-  priv->image = G_FILE(gis_store_get_object(GIS_STORE_IMAGE));
-  g_object_ref (priv->image);
-  basename = g_file_get_basename(priv->image);
+  priv->image = gis_store_get_selected_image ();
+  basename = g_file_get_basename (priv->image->file);
   if (basename == NULL)
     {
-      gchar *parse_name = g_file_get_parse_name(priv->image);
+      gchar *parse_name = g_file_get_parse_name (priv->image->file);
       g_warning ("g_file_get_basename(\"%s\") returned NULL", parse_name);
       g_free (parse_name);
       *error = g_error_new (GIS_INSTALL_ERROR, 0, _("Internal error"));
@@ -169,7 +166,7 @@ gis_install_page_prepare_read (GisPage *page, GError **error)
     }
   g_free (basename);
 
-  input = (GInputStream *) g_file_read (priv->image, NULL, &e);
+  input = (GInputStream *) g_file_read (priv->image->file, NULL, &e);
   if (e != NULL)
     {
       g_propagate_error (error, e);
@@ -302,9 +299,7 @@ gis_install_page_teardown (GisPage *page)
 
   g_mutex_lock (&priv->copy_mutex);
 
-  if (priv->image != NULL)
-    g_object_unref (priv->image);
-  priv->image = NULL;
+  g_clear_pointer (&priv->image, gis_image_free);
 
   if (priv->decompressor != NULL)
     g_object_unref (priv->decompressor);
@@ -359,7 +354,7 @@ gis_install_page_update_progress(GisPage *page)
 
   g_mutex_lock (&priv->copy_mutex);
 
-  gtk_progress_bar_set_fraction (bar, (gdouble)priv->bytes_written/(gdouble)priv->decompressed_size);
+  gtk_progress_bar_set_fraction (bar, (gdouble)priv->bytes_written/(gdouble)priv->image->uncompressed_size);
 
   g_mutex_unlock (&priv->copy_mutex);
 
@@ -621,13 +616,21 @@ gis_install_page_verify (GisPage *page)
 {
   GisInstallPage *install = GIS_INSTALL_PAGE (page);
   GisInstallPagePrivate *priv = gis_install_page_get_instance_private (install);
-  GFile *image = G_FILE(gis_store_get_object (GIS_STORE_IMAGE));
-  gchar *image_path = g_file_get_path (image);
-  const gchar *signature_path = gis_store_get_image_signature ();
-  GFile *signature = g_file_new_for_path (signature_path);
+
+  g_autofree gchar *image_path = g_file_get_path (priv->image->file);
+
+  GFile *signature = priv->image->signature;
+  g_autofree gchar *signature_path = g_file_get_path (signature);
+
   gint outfd;
-  guint64 size = gis_store_get_required_size ();
+
+  /* This size is a hint to GPG when it can't determine the size of image_path
+   * using stat(). This only occurs in the case where image_path is
+   * /dev/mapper/endless-image, ie the uncompressed image.
+   */
+  guint64 size = priv->image->uncompressed_size;
   g_autofree gchar *size_str = g_strdup_printf ("%" G_GUINT64_FORMAT, size);
+
   const gchar * const args[] = { "gpg",
                     "--enable-progress-filter", "--status-fd", "1",
                     /* Trust the one key in this keyring, and no others */
@@ -664,9 +667,7 @@ gis_install_page_verify (GisPage *page)
   g_child_watch_add (priv->gpg, (GChildWatchFunc)gis_install_page_gpg_watch, page);
 
 out:
-  g_free (image_path);
-  g_object_unref (signature);
-  return FALSE;
+  return G_SOURCE_REMOVE;
 }
 
 static void
@@ -679,6 +680,7 @@ gis_install_page_shown (GisPage *page)
   g_free (msg);
 
   priv->client = UDISKS_CLIENT (gis_store_get_object (GIS_STORE_UDISKS_CLIENT));
+  priv->image = gis_store_get_selected_image ();
 
   if (gis_store_get_error () != NULL)
     {

--- a/gnome-image-installer/util/gis-store.c
+++ b/gnome-image-installer/util/gis-store.c
@@ -27,15 +27,57 @@
 #include "gis-store.h"
 
 static GObject *_objects[GIS_STORE_N_OBJECTS];
-static guint64 _size = 0;
-static gint64 _image_size = 0;
-static gchar *_name = NULL;
-static gchar *_signature = NULL;
+static GisImage *_selected_image = NULL;
 static GError *_error = NULL;
 static gboolean _unattended = FALSE;
 static gboolean _live_install = FALSE;
 static GKeyFile *_keys = NULL;
 static gchar *_uuid = NULL;
+
+G_DEFINE_BOXED_TYPE(GisImage, gis_image, gis_image_copy, gis_image_free);
+
+GisImage *
+gis_image_new (const gchar *name,
+               GFile       *file,
+               GFile       *signature,
+               guint64      compressed_size,
+               guint64      uncompressed_size)
+{
+  GisImage *image;
+
+  g_return_val_if_fail (name != NULL, NULL);
+
+  g_return_val_if_fail (file != NULL, NULL);
+  g_return_val_if_fail (G_IS_FILE (file), NULL);
+
+  g_return_val_if_fail (signature != NULL, NULL);
+  g_return_val_if_fail (G_IS_FILE (signature), NULL);
+
+  image = g_slice_new0 (GisImage);
+  image->name = g_strdup (name);
+  image->file = g_object_ref (file);
+  image->signature = g_object_ref (signature);
+  image->compressed_size = compressed_size;
+  image->uncompressed_size = uncompressed_size;
+  return image;
+}
+
+GisImage *
+gis_image_copy (const GisImage *image)
+{
+  return gis_image_new (image->name, image->file, image->signature,
+      image->compressed_size, image->uncompressed_size);
+}
+
+void
+gis_image_free (GisImage *image)
+{
+  g_clear_pointer (&image->name, g_free);
+  g_clear_object (&image->file);
+  g_clear_object (&image->signature);
+
+  g_slice_free (GisImage, image);
+}
 
 GObject *gis_store_get_object(gint key)
 {
@@ -62,52 +104,19 @@ void gis_store_clear_object(gint key)
   _objects[key] = NULL;
 }
 
-guint64 gis_store_get_required_size(void)
+GisImage *
+gis_store_get_selected_image (void)
 {
-  return _size;
+  return _selected_image;
 }
 
-void gis_store_set_required_size(guint64 size)
+void
+gis_store_set_selected_image (const GisImage *image)
 {
-  _size = size;
-}
+  g_clear_pointer (&_selected_image, gis_image_free);
 
-gint64 gis_store_get_image_size (void)
-{
-  return _image_size;
-}
-
-void gis_store_set_image_size (gint64 size)
-{
-  _image_size = size;
-}
-
-gchar *gis_store_get_image_name(void)
-{
-  return _name;
-}
-
-void gis_store_set_image_name(gchar *name)
-{
-  g_free (_name);
-  _name = g_strdup (name);
-}
-
-void gis_store_clear_image_name(void)
-{
-  g_free (_name);
-  _name = NULL;
-}
-
-const gchar *gis_store_get_image_signature (void)
-{
-  return _signature;
-}
-
-void gis_store_set_image_signature (const gchar *signature)
-{
-  g_free (_signature);
-  _signature = g_strdup (signature);
+  if (image != NULL)
+    _selected_image = gis_image_copy (image);
 }
 
 const gchar *gis_store_get_image_uuid (void)

--- a/gnome-image-installer/util/gis-store.c
+++ b/gnome-image-installer/util/gis-store.c
@@ -39,6 +39,7 @@ G_DEFINE_BOXED_TYPE(GisImage, gis_image, gis_image_copy, gis_image_free);
 GisImage *
 gis_image_new (const gchar *name,
                GFile       *file,
+               GFile       *verify_file,
                GFile       *signature,
                guint64      compressed_size,
                guint64      uncompressed_size)
@@ -56,6 +57,7 @@ gis_image_new (const gchar *name,
   image = g_slice_new0 (GisImage);
   image->name = g_strdup (name);
   image->file = g_object_ref (file);
+  image->verify_file = g_object_ref (verify_file);
   image->signature = g_object_ref (signature);
   image->compressed_size = compressed_size;
   image->uncompressed_size = uncompressed_size;
@@ -65,8 +67,8 @@ gis_image_new (const gchar *name,
 GisImage *
 gis_image_copy (const GisImage *image)
 {
-  return gis_image_new (image->name, image->file, image->signature,
-      image->compressed_size, image->uncompressed_size);
+  return gis_image_new (image->name, image->file, image->verify_file,
+      image->signature, image->compressed_size, image->uncompressed_size);
 }
 
 void
@@ -74,6 +76,7 @@ gis_image_free (GisImage *image)
 {
   g_clear_pointer (&image->name, g_free);
   g_clear_object (&image->file);
+  g_clear_object (&image->verify_file);
   g_clear_object (&image->signature);
 
   g_slice_free (GisImage, image);

--- a/gnome-image-installer/util/gis-store.h
+++ b/gnome-image-installer/util/gis-store.h
@@ -34,14 +34,28 @@ typedef struct _GisImage {
   /* Human-readable name */
   gchar *name;
 
-  /* Image file. This may be a device (eg /dev/mapper/endless-image) or a
-   * regular file (eg /path/to/eos-...img.gz) */
+  /* Image file to write to disk. This may be a device (eg
+   * /dev/mapper/endless-image) or a regular file (eg /path/to/eos-...img.gz)
+   */
   GFile *file;
+
+  /* Image file to verify. This may be a device (eg
+   * /dev/mapper/endless-image-squashfs) or a regular file (eg
+   * /path/to/eos-...img.gz, /path/to/endless.squash).
+   *
+   * When installing a SquashFS-compressed image file, we rely on the
+   * uncompressed file within being mapped to a loopback device (and then to
+   * /dev/mapper/endless-image). But we still want to *verify* the compressed
+   * SquashFS image.
+   *
+   * When not installing from SquashFS, this will be the same as 'file'.
+   */
+  GFile *verify_file;
 
   /* GPG signature for 'file' */
   GFile *signature;
 
-  /* Size of 'file' */
+  /* Size of 'verify_file' */
   guint64 compressed_size;
 
   /* Size of image when uncompressed and written to disk. */
@@ -51,6 +65,7 @@ typedef struct _GisImage {
 GType gis_image_get_type (void);
 GisImage *gis_image_new (const gchar *name,
                          GFile       *file,
+                         GFile       *verify_file,
                          GFile       *signature,
                          guint64      compressed_size,
                          guint64      uncompressed_size);

--- a/gnome-image-installer/util/gis-store.h
+++ b/gnome-image-installer/util/gis-store.h
@@ -30,17 +30,42 @@
 
 G_BEGIN_DECLS
 
-typedef enum {
-  /* GFile: selected image path */
-  GIS_STORE_IMAGE = 0,
+typedef struct _GisImage {
+  /* Human-readable name */
+  gchar *name;
 
+  /* Image file. This may be a device (eg /dev/mapper/endless-image) or a
+   * regular file (eg /path/to/eos-...img.gz) */
+  GFile *file;
+
+  /* GPG signature for 'file' */
+  GFile *signature;
+
+  /* Size of 'file' */
+  guint64 compressed_size;
+
+  /* Size of image when uncompressed and written to disk. */
+  guint64 uncompressed_size;
+} GisImage;
+
+GType gis_image_get_type (void);
+GisImage *gis_image_new (const gchar *name,
+                         GFile       *file,
+                         GFile       *signature,
+                         guint64      compressed_size,
+                         guint64      uncompressed_size);
+GisImage *gis_image_copy (const GisImage *image);
+void gis_image_free (GisImage *image);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GisImage, gis_image_free);
+
+typedef enum {
   /* UDisksBlock: block device to reformat */
-  GIS_STORE_BLOCK_DEVICE,
+  GIS_STORE_BLOCK_DEVICE = 0,
 
   /* UDisksClient: global shared UDisks client proxy */
   GIS_STORE_UDISKS_CLIENT,
 
-  /* UDisksDrive: drive hosting partition hosting GIS_STORE_IMAGE */
+  /* UDisksDrive: drive hosting partition hosting the selected image */
   GIS_STORE_IMAGE_DRIVE,
 
   GIS_STORE_N_OBJECTS
@@ -50,21 +75,11 @@ GObject *gis_store_get_object(gint key);
 void gis_store_set_object(gint key, GObject *obj);
 void gis_store_clear_object(gint key);
 
-guint64 gis_store_get_required_size(void);
-void gis_store_set_required_size(guint64 size);
-
-gint64 gis_store_get_image_size (void);
-void gis_store_set_image_size (gint64 size);
-
-gchar *gis_store_get_image_name(void);
-void gis_store_set_image_name(gchar *name);
-void gis_store_clear_image_name(void);
+void gis_store_set_selected_image (const GisImage *image);
+GisImage *gis_store_get_selected_image (void);
 
 const gchar *gis_store_get_image_uuid(void);
 void gis_store_set_image_uuid(const gchar *uuid);
-
-const gchar *gis_store_get_image_signature(void);
-void gis_store_set_image_signature(const gchar *signature);
 
 GError *gis_store_get_error(void);
 void gis_store_set_error(GError *error);


### PR DESCRIPTION
From 3.3.x onwards, we include .squash.asc in the ISO image and write
"<image basename>.squash" rather than "<image basename>.img" to the
'live' file. This allows us to verify the squashfs image rather than
decompressing it, verifying the decompressed contents, discarding them,
then decompressing it again to write it to disk.

As ever, this is made more complicated by the image-mapping stuff. In fact,
in the ISO case endless.squash will not be mapped. But when creating
exFAT-formatted USB sticks from an ISO, we would like to be able to copy
endless.squash, rather than decompressing it, to save space on the USB
stick. This is supported by the boot scripts, so, hooray, we get to support
it here too.

Includes a nice cleanup of passing all the facts about each image around.

https://phabricator.endlessm.com/T17203