### PR TITLE
Update gnome-session file for gnome-settings-daemon 3.23

### DIFF
--- a/eos-installer-data/eos-installer.session
+++ b/eos-installer-data/eos-installer.session
@@ -1,3 +1,3 @@
 [GNOME Session]
 Name=EOS Installer
-RequiredComponents=eos-setup-shell;eos-installer;gnome-settings-daemon;
+RequiredComponents=eos-setup-shell;eos-installer;org.gnome.SettingsDaemon.A11yKeyboard;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Clipboard;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Mouse;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;


### PR DESCRIPTION
Side-port of d2c051c1266a107e2cc87feb3f1212eda0ef7fd6 from gnome-initial-setup:

> data: Update gnome-session file for gnome-settings-daemon 3.23
>
> gnome-settings-daemon has been split up into separate daemons, which
> means we'll need to invoke those separately.
>
> See https://git.gnome.org/browse/gnome-session/commit?id=18b6e567e1a
> for the corresponding change to the regular session file.
>
> https://bugzilla.gnome.org/show_bug.cgi?id=778309

Without this, the session fails to start:

> gnome-session[685]: gnome-session-binary[685]: WARNING: Unable to find required component 'gnome-settings-daemon'
> gnome-session-binary[685]: WARNING: Unable to find required component 'gnome-settings-daemon'
> gnome-session-binary[685]: Entering running state
> gnome-session[685]: Unable to init server: Could not connect: Connection refused

Do we need all these components? Probably not.

https://phabricator.endlessm.com/T19742