### PR TITLE
Fully remove egg-list-box submodule, propagate errors from autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
+set -ex
 
 srcdir=`dirname $0`
 test -z "$srcdir" && srcdir=.


### PR DESCRIPTION
I am still a bit suspicious of this pattern:

    if ! test -f ext/libglnx/README.md; then
        git submodule update --init
    fi

because, since we re-use an existing checkout on Jenkins rather than recreating it, the submodule will never actually be updated. However, this problem also exists for other projects which use this pattern (a quick search of my local checkouts turned up flatpak and ostree) and it strikes me that the best solution is to build in a fresh workspace each time.

https://phabricator.endlessm.com/T13661