### PR TITLE
Add missing (build-)dep on gnupg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,7 +38,8 @@ Build-Depends: cdbs (>= 0.4.41),
 	       libwebkit2gtk-4.0-dev,
 	       libudisks2-dev,
 	       liblzma-dev,
-	       libattr1-dev
+	       libattr1-dev,
+	       gnupg,
 Standards-Version: 3.9.4
 Homepage: https://endlessm.com
 
@@ -48,6 +49,7 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          eos-image-keyring,
          gdm3,
+         gnupg,
 	 policykit-1 (>= 0.106)
 Description: Endless OS installer
 


### PR DESCRIPTION
The run-time dependency is redundant with the dependency on
eos-image-keyring but one likes to be explicit. The build-dependency is
newly needed by the test suite.

https://phabricator.endlessm.com/T13661