### PR TITLE
install: fix size mismatch error message

### DIFF
--- a/gnome-image-installer/pages/install/gis-scribe.c
+++ b/gnome-image-installer/pages/install/gis-scribe.c
@@ -659,7 +659,7 @@ gis_scribe_write_thread_copy (GisScribe     *self,
     {
       g_set_error (error, GIS_INSTALL_ERROR, 0,
                    "wrote %" G_GUINT64_FORMAT " bytes, "
-                   "expected to write %" G_GUINT64_FORMAT "bytes",
+                   "expected to write %" G_GUINT64_FORMAT " bytes",
                    bytes_written, self->image_size_bytes);
       return FALSE;
     }


### PR DESCRIPTION
There was previously no space between the second number and the word
"bytes".

The comment above this block reads:

> Check that we've written the same amount of data as we expected from the
> GPT header. This would only fail if there's something seriously wrong with
> the image builder, the decompressor, or the read/write loop above.

Almost by chance, a bug was introduced into the image builder
simultaneously with introducing this check, such that the image size was
not a multiple of the sector size. We calculate the expected size from
the GPT header (which expresses size in 512-byte sectors) so the actual
size could be up to 511 bytes larger! In this case the extra bytes are
harmless (unless your hard disk happens to be exactly sized so that this
makes a difference), but it's still gratifying to have caught this.

https://phabricator.endlessm.com/T13661
https://phabricator.endlessm.com/T20064