### PR TITLE
finished: remove support email address from translated string

### DIFF
--- a/gnome-image-installer/pages/finished/Makefile.am
+++ b/gnome-image-installer/pages/finished/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = \
 	$(INITIAL_SETUP_CFLAGS) \
 	$(IMAGE_INSTALLER_CFLAGS) \
 	-DLOCALSTATEDIR="\"$(localstatedir)\"" \
+	-DDATADIR="\"$(datadir)\"" \
 	-DUIDIR="\"$(uidir)\""
 
 BUILT_SOURCES =

--- a/gnome-image-installer/pages/finished/gis-finished-page.ui
+++ b/gnome-image-installer/pages/finished/gis-finished-page.ui
@@ -131,7 +131,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="margin_top">16</property>
-                <property name="label" translatable="yes">Please contact &lt;a href="mailto:support@endlessm.com"&gt;support@endlessm.com&lt;/a&gt; or join the &lt;a href="https://community.endlessos.com/"&gt;Endless Community&lt;/a&gt; to troubleshoot.</property>
+                <property name="label">Please contact &lt;a href="mailto:support@endlessm.com"&gt;support@endlessm.com&lt;/a&gt; or join the &lt;a href="https://community.endlessos.com/"&gt;Endless Community&lt;/a&gt; to troubleshoot.</property>
                 <property name="use_markup">True</property>
                 <property name="justify">center</property>
                 <property name="wrap">True</property>


### PR DESCRIPTION
For some languages (es, pt, id) we use a different customer support
email address; for all other languages we use support@endlessm.com.
Previously we handled this by including the email address in the string
to be translated, changing the address in those three translations, and
relying on translators for other languages to leave it unmodified.

However, Transifex now does not allow the target of the link to be
edited in the translation. The string would show up in Transifex as:

> Please contact <1>support@endlessm.com<1> or join the <2>Endless Community<2> to troubleshoot.

where <1> and <2> are special symbols that the Transifex user cannot
manipulate. For the forum link this is desirable, but for the mailto:
link it is not.

In the Shell, we already have a different mechanism to vary the support
email address by locale. So, we can reuse this here, and replace the
email link in the translatable string with a placeholder.

https://phabricator.endlessm.com/T19689