### PR TITLE
control: add missing udisks2 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,8 @@ Depends: ${shlibs:Depends},
          eos-image-keyring,
          gdm3,
          gnupg,
-	 policykit-1 (>= 0.106)
+	 policykit-1 (>= 0.106),
+	 udisks2,
 Description: Endless OS installer
 
 Package: eos-installer-dbg


### PR DESCRIPTION
Previously this was (apparently) only pulled into the eosinstaller image
via Recommends:, since it was present in the 180201 nightly but not the
180202.

Since eos-installer speaks to UDisks2 over D-Bus to find images and
target disks, it works rather badly if it is not installed.

https://phabricator.endlessm.com/T5124