### PR TITLE
Add extra checks and logging to scribe; fix many warnings

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libglnx"]
 	path = ext/libglnx
-	url = https://git.gnome.org/browse/libglnx
+	url = https://gitlab.gnome.org/GNOME/libglnx.git

--- a/eos-installer.doap
+++ b/eos-installer.doap
@@ -4,16 +4,16 @@
          xmlns:gnome="http://api.gnome.org/doap-extensions#"
          xmlns="http://usefulinc.com/ns/doap#">
 
-  <name xml:lang="en">Endless OS Installer</name>
-  <shortdesc xml:lang="en">Installing your OS</shortdesc>
+  <name xml:lang="en">Endless OS Reformatter</name>
+  <shortdesc xml:lang="en">Reformat your computer with Endless OS</shortdesc>
 
   <category rdf:resource="http://api.gnome.org/doap-extensions#desktop" />
 
   <maintainer>
     <foaf:Person>
-      <foaf:name>Jasper St. Pierre</foaf:name>
-      <foaf:mbox rdf:resource="mailto:jstpierre@mecheye.net" />
-      <gnome:userid>jstpierre</gnome:userid>
+      <foaf:name>Will Thompson</foaf:name>
+      <foaf:mbox rdf:resource="mailto:wjt@endlessm.com" />
+      <gnome:userid>wjt</gnome:userid>
     </foaf:Person>
   </maintainer>
 </Project>

--- a/gnome-image-installer/gnome-image-installer.c
+++ b/gnome-image-installer/gnome-image-installer.c
@@ -77,6 +77,10 @@ destroy_pages_after (GisAssistant *assistant,
     if (l->data == page)
       break;
 
+  /* This function is called with the current page, so it should certainly be
+   * found in list of pages.
+   */
+  g_return_if_fail (l != NULL);
   l = l->next;
   for (; l != NULL; l = next) {
     next = l->next;

--- a/gnome-image-installer/pages/finished/gis-finished-page.c
+++ b/gnome-image-installer/pages/finished/gis-finished-page.c
@@ -37,6 +37,7 @@
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <gio/gdesktopappinfo.h>
+#include <locale.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <attr/xattr.h>

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -158,9 +158,11 @@ gis_install_page_teardown (GisPage *page)
 }
 
 static gboolean
-gis_install_page_pulse_progress (GtkProgressBar *bar)
+gis_install_page_pulse_progress (GtkWidget *bar,
+                                 GdkFrameClock *frame_clock,
+                                 gpointer user_data)
 {
-  gtk_progress_bar_pulse (bar);
+  gtk_progress_bar_pulse (GTK_PROGRESS_BAR (bar));
 
   return TRUE;
 }
@@ -175,7 +177,7 @@ gis_install_page_ensure_pulsing (GisInstallPage *page)
       gtk_progress_bar_set_pulse_step (priv->install_progress, 1. / 60.);
       priv->pulse_id = gtk_widget_add_tick_callback (
           GTK_WIDGET (priv->install_progress),
-          (GtkTickCallback) gis_install_page_pulse_progress,
+          gis_install_page_pulse_progress,
           NULL, NULL);
     }
 }

--- a/gnome-image-installer/pages/install/gis-install-page.c
+++ b/gnome-image-installer/pages/install/gis-install-page.c
@@ -278,7 +278,7 @@ gis_install_page_open_for_restore_cb (GObject      *source,
       goto error;
     }
 
-  image = g_object_ref (gis_store_get_object (GIS_STORE_IMAGE));
+  image = g_object_ref (G_FILE (gis_store_get_object (GIS_STORE_IMAGE)));
   signature_path = gis_store_get_image_signature ();
   signature = g_file_new_for_path (signature_path);
 

--- a/gnome-image-installer/pages/install/gis-scribe.c
+++ b/gnome-image-installer/pages/install/gis-scribe.c
@@ -1072,7 +1072,7 @@ gis_scribe_begin_verify (GisScribe *self,
     g_pollable_input_stream_create_source (G_POLLABLE_INPUT_STREAM (gpg_stdout),
                                            cancellable);
   g_task_attach_source (task, task_data->stdout_source,
-                        (GSourceFunc) gis_scribe_gpg_progress);
+                        (GSourceFunc) (void (*)(void)) gis_scribe_gpg_progress);
 
   g_subprocess_wait_check_async (task_data->subprocess, cancellable,
                                  gis_scribe_gpg_wait_check_cb,

--- a/gnome-image-installer/pages/install/gis-scribe.c
+++ b/gnome-image-installer/pages/install/gis-scribe.c
@@ -1034,6 +1034,7 @@ gis_scribe_begin_verify (GisScribe *self,
       "--input-size-hint", size_str,
       "--verify", signature_path, "-", NULL
   };
+  g_autofree gchar *args_flat = g_strjoinv (" ", (gchar **) args);
   g_autoptr(GSubprocessLauncher) launcher = NULL;
   GInputStream *gpg_stdout = NULL;
   GOutputStream *gpg_stdin = NULL;
@@ -1052,6 +1053,7 @@ gis_scribe_begin_verify (GisScribe *self,
       return NULL;
     }
 
+  g_message ("Spawning %s", args_flat);
   launcher = g_subprocess_launcher_new (G_SUBPROCESS_FLAGS_STDIN_PIPE |
                                         G_SUBPROCESS_FLAGS_STDOUT_PIPE);
   task_data->subprocess = g_subprocess_launcher_spawnv (launcher, args, &error);

--- a/gnome-image-installer/pages/install/gis-scribe.c
+++ b/gnome-image-installer/pages/install/gis-scribe.c
@@ -815,8 +815,6 @@ gis_scribe_write_thread (GTask        *task,
 
   if (!ret)
     {
-      g_autoptr(GError) close_error = NULL;
-
       if (error == NULL)
         {
           /* This path should not be reached. To avoid translators

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -93,7 +93,11 @@ w.truncated.%z: w.img.%z
 		--gpgconf-path $(GPGCONF_PATH) \
 		$(srcdir)/secret.asc $<
 
-test_scribe_SOURCES = test-scribe.c
+test_scribe_SOURCES = \
+	test-error-input-stream.c \
+	test-error-input-stream.h \
+	test-scribe.c \
+	$(NULL)
 test_scribe_CFLAGS = \
 	$(INITIAL_SETUP_CFLAGS) \
 	$(IMAGE_INSTALLER_CFLAGS) \

--- a/tests/test-error-input-stream.c
+++ b/tests/test-error-input-stream.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+#include "config.h"
+#include "test-error-input-stream.h"
+
+/* We store the maximum offset as a guint64, due to it being a property and
+ * there being no GType for gsize. The GInputStream API is in terms of
+ * g(s)size.
+ */
+G_STATIC_ASSERT (G_MAXSIZE <= G_MAXUINT64);
+
+typedef struct _TestErrorInputStream {
+  GInputStream parent;
+
+  GInputStream *child;
+  guint64 error_offset;
+  GError *error;
+
+  gsize pos;
+} TestErrorInputStream;
+
+typedef enum {
+  PROP_CHILD = 1,
+  PROP_ERROR_OFFSET,
+  PROP_ERROR,
+
+  N_PROPERTIES
+} TestErrorInputStreamPropertyId;
+
+static GParamSpec *props[N_PROPERTIES] = { 0 };
+
+G_DEFINE_TYPE (TestErrorInputStream, test_error_input_stream, G_TYPE_INPUT_STREAM);
+
+static void
+test_error_input_stream_init (TestErrorInputStream *self)
+{
+}
+
+static void
+test_error_input_stream_constructed (GObject *object)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (object);
+
+  G_OBJECT_CLASS (test_error_input_stream_parent_class)->constructed (object);
+
+  g_assert (self->child != NULL);
+  g_assert (self->error != NULL);
+}
+
+static void
+test_error_input_stream_set_property (GObject      *object,
+                                      guint         property_id,
+                                      const GValue *value,
+                                      GParamSpec   *pspec)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (object);
+
+  switch ((TestErrorInputStreamPropertyId) property_id)
+    {
+    case PROP_CHILD:
+      g_clear_object (&self->child);
+      self->child = G_INPUT_STREAM (g_value_dup_object (value));
+      break;
+
+    case PROP_ERROR_OFFSET:
+      self->error_offset = g_value_get_uint64 (value);
+      break;
+
+    case PROP_ERROR:
+      g_clear_error (&self->error);
+      self->error = g_value_dup_boxed (value);
+      g_assert (self->error != NULL);
+      break;
+
+    case N_PROPERTIES:
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+    }
+}
+
+static void
+test_error_input_stream_dispose (GObject *object)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (object);
+
+  g_clear_object (&self->child);
+
+  G_OBJECT_CLASS (test_error_input_stream_parent_class)->dispose (object);
+}
+
+static void
+test_error_input_stream_finalize (GObject *object)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (object);
+
+  g_clear_error (&self->error);
+
+  G_OBJECT_CLASS (test_error_input_stream_parent_class)->finalize (object);
+}
+
+static gssize
+test_error_input_stream_read (GInputStream        *stream,
+                              void                *buffer,
+                              gsize                count,
+                              GCancellable        *cancellable,
+                              GError             **error)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (stream);
+  gssize bytes_read;
+
+  if (self->pos + count > self->error_offset)
+    {
+      g_propagate_error (error, g_error_copy (self->error));
+      return -1;
+    }
+
+  bytes_read = g_input_stream_read (self->child, buffer, count, cancellable,
+                                    error);
+  if (bytes_read >= 0)
+    self->pos += bytes_read;
+
+  return bytes_read;
+}
+
+static gboolean
+test_error_input_stream_close (GInputStream        *stream,
+                               GCancellable        *cancellable,
+                               GError             **error)
+{
+  TestErrorInputStream *self = TEST_ERROR_INPUT_STREAM (stream);
+
+  return g_input_stream_close (self->child, cancellable, error);
+}
+
+static void
+test_error_input_stream_class_init (TestErrorInputStreamClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GInputStreamClass *istream_class = G_INPUT_STREAM_CLASS (klass);
+
+  object_class->set_property = test_error_input_stream_set_property;
+  object_class->constructed = test_error_input_stream_constructed;
+  object_class->dispose = test_error_input_stream_dispose;
+  object_class->finalize = test_error_input_stream_finalize;
+
+  istream_class->read_fn = test_error_input_stream_read;
+  /* Allow parent class to emulate skip. We don't use it anyway. */
+  istream_class->close_fn = test_error_input_stream_close;
+
+  props[PROP_CHILD] = g_param_spec_object (
+      "child",
+      "Child",
+      "Child stream to delegate to until :error_offset is reached.",
+      G_TYPE_INPUT_STREAM,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  props[PROP_ERROR_OFFSET] = g_param_spec_uint64 (
+      "error-offset",
+      "Error Offset",
+      "Offset at which reads will start to fail.",
+      0, G_MAXUINT64, 0,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  props[PROP_ERROR] = g_param_spec_boxed (
+      "error",
+      "Error",
+      "Error to return once :error-offset is reached.",
+      G_TYPE_ERROR,
+      G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (object_class, N_PROPERTIES, props);
+}
+
+GInputStream *
+test_error_input_stream_new (GInputStream *child,
+                             guint64       error_offset,
+                             const GError *error)
+{
+  return g_object_new (TEST_TYPE_ERROR_INPUT_STREAM,
+                       "child", child,
+                       "error-offset", error_offset,
+                       "error", error,
+                       NULL);
+}

--- a/tests/test-error-input-stream.h
+++ b/tests/test-error-input-stream.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2018 Endless Mobile, Inc.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+#define TEST_TYPE_ERROR_INPUT_STREAM (test_error_input_stream_get_type ())
+G_DECLARE_FINAL_TYPE (TestErrorInputStream, test_error_input_stream,
+                      TEST, ERROR_INPUT_STREAM, GInputStream);
+
+GInputStream *test_error_input_stream_new (GInputStream *child,
+                                           guint64       error_offset,
+                                           const GError *error);

--- a/tests/test-scribe.c
+++ b/tests/test-scribe.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <locale.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
I saw a transient GPG verification failure when reformatting from a nightly ISO in a virtual machine. There was no useful information in the journal (beyond GPG's "BAD signature" output); re-running the process (without a reboot or anything) worked fine; and I manually GPG-verified the ISO, the squashfs within it, and the uncompressed image within that. Mysterious!

There isn't really much to go on. Maybe this was a transient read error from the USB disk on which the ISO is stored. Maybe a cosmic ray flipped a bit. But in case it happens again, here is some extra debug output and an extra coherence check in the scribe.

I also included many warning fixes, found by editing this project in GNOME Builder building against a non-Endless system.