### PR TITLE
tests: work around CI failure

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# The default is 79 characters. One popular Python code formatter
+# https://github.com/ambv/black#line-length defaults to 88 which is based on
+# some empirical research on reducing annoying line wrapping on real source
+# code.
+max-line-length = 88

--- a/tests/sign-file
+++ b/tests/sign-file
@@ -15,13 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 import argparse
+import logging
 import os
+import shlex
 import subprocess
 import tempfile
 
 
+LOGGER = logging.getLogger(os.path.basename(__file__))
+
+
 def cmd(*args):
-    print('$', *args)
+    LOGGER.info("$ %s", " ".join(map(shlex.quote, args)))
     subprocess.check_call(args)
 
 
@@ -36,6 +41,8 @@ def main():
 
     Using a purely transient temporary directory also helps ensure this is
     isolated from the host system.'''
+    logging.basicConfig(level=logging.INFO)
+
     p = argparse.ArgumentParser(description=description, epilog=epilog)
     p.add_argument('--gpg-path', default='gpg', help='Path to GPG')
     p.add_argument('--gpgconf-path', default='gpgconf', help='Path to gpgconf')

--- a/tests/sign-file
+++ b/tests/sign-file
@@ -61,6 +61,18 @@ def main():
             "--armor", a.file)
         cmd(a.gpgconf_path, "--homedir", gnupghome, "--kill", "gpg-agent")
 
+        # When running on Jenkins, this socket is sometimes unlinked midway
+        # through TemporaryDirectory.cleanup(). There is no way to tell
+        # TemporaryDirectory.cleanup() to ignore errors, even though the
+        # underlying function (shutil.rmtree) supports this. Work around this
+        # by ensuring the socket is unlinked before
+        # TemporaryDirectory.cleanup() is called (by
+        # TemporaryDirectory.__exit__() when we leave this scope).
+        try:
+            os.unlink(os.path.join(gnupghome, "S.gpg-agent.extra"))
+        except FileNotFoundError:
+            pass
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Here's the log from the [failing run](https://ci.endlessm-sf.com/job/obs-eos-installer-master/210/console):

    $ /usr/bin/gpgconf --homedir /tmp/tmp1fc9sfpr --kill gpg-agent
    Traceback (most recent call last):
      File "../../../tests/sign-file", line 59, in <module>
        main()
      File "../../../tests/sign-file", line 55, in main
        cmd(a.gpgconf_path, "--homedir", gnupghome, "--kill", "gpg-agent")
      File "/usr/lib/python3.7/tempfile.py", line 944, in __exit__
        self.cleanup()
      File "/usr/lib/python3.7/tempfile.py", line 948, in cleanup
        _rmtree(self.name)
      File "/usr/lib/python3.7/shutil.py", line 491, in rmtree
        _rmtree_safe_fd(fd, path, onerror)
      File "/usr/lib/python3.7/shutil.py", line 449, in _rmtree_safe_fd
        onerror(os.unlink, fullname, sys.exc_info())
      File "/usr/lib/python3.7/shutil.py", line 447, in _rmtree_safe_fd
        os.unlink(entry.name, dir_fd=topfd)
    FileNotFoundError: [Errno 2] No such file or directory: 'S.gpg-agent.extra'
    make[4]: *** [Makefile:1683: T20064.171120-020312.img.asc] Error 1

The only explanation I can find is the one in the comment added by this PR. Work around this and add some other stuff I wrote while trying and failing to pass an `onerror` handler to `shutil.rmtree()`. (If I just call it myself, then `TemporaryDirectory.cleanup()` fails because the directory is already gone…)

I guess I should file a bug against Python but I can't find the strength.

https://phabricator.endlessm.com/T27872