### PR TITLE
Fix path to xattr.h header

### DIFF
--- a/gnome-image-installer/pages/finished/gis-finished-page.c
+++ b/gnome-image-installer/pages/finished/gis-finished-page.c
@@ -40,7 +40,7 @@
 #include <locale.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #include <udisks/udisks.h>
 


### PR DESCRIPTION
`xattr.h` has been moved into glibc.