### PR TITLE
Allow images without separate /efi & /boot partitions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,3 +22,7 @@ EXTRA_DIST = \
 
 DISTCHECK_CONFIGURE_FLAGS = \
     --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+
+# FIXME: Work around https://bugs.launchpad.net/intltool/+bug/1712194
+distclean-local:
+	rm -f po/.intltool-merge-cache.lock


### PR DESCRIPTION
This is for GNOME OS where we use systemd boot where we do not require
the use of a separate partition.

https://phabricator.endlessm.com/T30030