### PR TITLE
Allow loop device for installation target

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,11 @@ One way to run this application while developing it is with the following setup:
   signature. This can be a loopback device if you want to avoid using removable
   media, but it has to have a GPT. (xz decompression is really slow, so gz is
   strongly recommended.)
-* Disk 2: a target disk large enough to write the OS image to. `eos-installer`
-  only considers non-removable disks with a corresponding block device to be
-  install targets, so unless you have a computer with multiple built-in disks,
-  you'll need to either do all this in a virtual machine with multiple fixed
-  disks, or temporarily patch the checks in the `disktarget` page to allow a
-  loopback device or removable disk to be the install target.
+* Disk 2: a target disk or loop associated file large enough to write the OS
+  image to. `eos-installer` only considers non-removable disks with a
+  corresponding block device to be install targets, so unless you have a
+  computer with multiple built-in disks, you'll need to either do all this in a
+  virtual machine with multiple fixed disks, or use a loopback device.
 
 If you do not have an `eosimages` partition with at least one image file on it,
 running the app will take you straight to the error screen.

--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -600,13 +600,20 @@ gis_diskimage_page_mount (GisPage *page)
       drive = udisks_client_get_drive_for_block (client, block);
       if (drive != NULL)
         {
-          gis_store_set_object (GIS_STORE_IMAGE_DRIVE, G_OBJECT (drive));
+          gis_store_set_object (GIS_STORE_IMAGE_SOURCE, G_OBJECT (drive));
           g_clear_object (&drive);
+        }
+      else
+        {
+          g_autoptr(UDisksLoop) loop = udisks_client_get_loop_for_block (client,
+                                                                         block);
+          if (loop != NULL)
+            gis_store_set_object (GIS_STORE_IMAGE_SOURCE, G_OBJECT (loop));
         }
       /* If running from exFAT or NTFS, where we use device mapper rather than
        * loopback mount, the image host partition we use is on another mapped
        * device (because we can't mount the real one directly). In this case,
-       * the UDisksBlock has no associated UDisksDrive.
+       * the UDisksBlock has no associated UDisksDrive or UDisksLoop.
        */
 
       mounts = udisks_filesystem_get_mount_points (fs);

--- a/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
+++ b/gnome-image-installer/pages/disktarget/gis-disktarget-page.c
@@ -64,6 +64,7 @@ check_can_continue(GisDiskTargetPage *page)
   GisDiskTargetPagePrivate *priv = gis_disktarget_page_get_instance_private (page);
   UDisksBlock *block = UDISKS_BLOCK (gis_store_get_object (GIS_STORE_BLOCK_DEVICE));
   UDisksDrive *drive = NULL;
+  guint64 available;
 
   if (!priv->has_valid_disks)
     return;
@@ -74,10 +75,8 @@ check_can_continue(GisDiskTargetPage *page)
     return;
 
   drive = udisks_client_get_drive_for_block (priv->client, UDISKS_BLOCK(block));
-  if (drive == NULL)
-    return;
-
-  if (udisks_drive_get_size(drive) < gis_store_get_required_size())
+  available = drive ? udisks_drive_get_size (drive) : udisks_block_get_size (block);
+  if (available < gis_store_get_required_size())
     return;
 
   if (!gtk_toggle_button_get_active (priv->confirm_button))
@@ -121,9 +120,10 @@ gis_disktarget_page_selection_changed(GtkWidget *combo, GisPage *page)
   if (block != NULL)
     {
       UDisksDrive *drive = udisks_client_get_drive_for_block (priv->client, UDISKS_BLOCK(block));
+      guint64 available = drive ? udisks_drive_get_size (drive) : udisks_block_get_size (UDISKS_BLOCK(block));
       gis_store_set_object (GIS_STORE_BLOCK_DEVICE, block);
       g_object_unref(block);
-      if (udisks_drive_get_size(drive) < gis_store_get_required_size())
+      if (available < gis_store_get_required_size())
         {
           g_autofree gchar *size = g_format_size_full (
               gis_store_get_required_size (),
@@ -287,51 +287,79 @@ gis_disktarget_page_populate_model(GisPage *page, UDisksClient *client)
       gchar *targetname, *targetsize;
       UDisksObject *object = UDISKS_OBJECT(l->data);
       const gchar *object_path;
+      const gchar *object_type;
       UDisksDrive *drive = udisks_object_peek_drive(object);
+      UDisksLoop *loop = udisks_object_peek_loop(object);
       UDisksBlock *block;
       const gchar *block_device;
       gboolean has_data_partitions;
-      if (drive == NULL)
+      if (drive == NULL && loop == NULL)
         continue;
 
       object_path = g_dbus_object_get_object_path (G_DBUS_OBJECT (object));
+      object_type = drive ? "drive" : "loop";
 
 #define skip_if(cond, reason, ...) \
       if (cond) \
         { \
-          g_message ("skipping drive %s: " reason, object_path, ##__VA_ARGS__); \
+          g_message ("skipping %s %s: " reason, object_type, object_path, ##__VA_ARGS__); \
           continue; \
         }
 
-      skip_if (drive == root, "it is the root device");
-      skip_if (udisks_drive_get_optical (drive), "optical");
-      skip_if (udisks_drive_get_ejectable (drive), "ejectable");
+      if (drive)
+        {
+          skip_if (drive == root, "it is the root device");
+          skip_if (udisks_drive_get_optical (drive), "optical");
+          skip_if (udisks_drive_get_ejectable (drive), "ejectable");
 
-      block = udisks_client_get_block_for_drive(client, drive, TRUE);
-      skip_if (block == NULL, "no corresponding block object");
+          block = udisks_client_get_block_for_drive(client, drive, TRUE);
+          skip_if (block == NULL, "no corresponding block object");
 
-      skip_if (0 == g_strcmp0 (object_path, image_drive_path),
-               "it hosts the image partition");
+          skip_if (0 == g_strcmp0 (object_path, image_drive_path),
+                   "it hosts the image partition");
+
+          if (udisks_drive_get_size(drive) >= gis_store_get_required_size())
+            {
+              priv->has_valid_disks = TRUE;
+            }
+
+          targetname = g_strdup_printf("%s %s",
+                                       udisks_drive_get_vendor(drive),
+                                       udisks_drive_get_model(drive));
+          targetsize = g_format_size_full (udisks_drive_get_size(drive),
+                                           G_FORMAT_SIZE_DEFAULT);
+        }
+      else
+        {
+          const gchar *backing_file = udisks_loop_get_backing_file (loop);
+          skip_if (backing_file == NULL || *backing_file == '\0',
+                   "no backing file");
+
+          block = udisks_object_peek_block (object);
+          skip_if (block == NULL, "no corresponding block object");
+
+          if (udisks_block_get_size (block) >= gis_store_get_required_size ())
+            {
+              priv->has_valid_disks = TRUE;
+            }
+
+          targetname = g_strdup_printf("%s %s",
+                                       udisks_block_get_device (block),
+                                       backing_file);
+          targetsize = g_format_size_full (udisks_block_get_size (block),
+                                           G_FORMAT_SIZE_DEFAULT);
+        }
+
       block_device = udisks_block_get_device (block);
       skip_if (config != NULL &&
                !gis_unattended_config_matches_device (config, block_device),
                "it doesn't match the unattended config");
 #undef skip_if
 
-      g_message ("adding drive %s to list", object_path);
-
-      if (udisks_drive_get_size(drive) >= gis_store_get_required_size())
-        {
-          priv->has_valid_disks = TRUE;
-        }
+      g_message ("adding %s %s to list", object_type, object_path);
 
       has_data_partitions = gis_disktarget_page_has_data_partitions(page, objects, block);
 
-      targetname = g_strdup_printf("%s %s",
-                                   udisks_drive_get_vendor(drive),
-                                   udisks_drive_get_model(drive));
-      targetsize = g_format_size_full (udisks_drive_get_size(drive),
-                                       G_FORMAT_SIZE_DEFAULT);
       gtk_list_store_append (priv->target_store, &i);
       gtk_list_store_set (priv->target_store, &i,
                           0, targetname,

--- a/gnome-image-installer/util/gis-store.h
+++ b/gnome-image-installer/util/gis-store.h
@@ -45,10 +45,11 @@ typedef enum {
    */
   GIS_STORE_IMAGE_DIR,
 
-  /* UDisksDrive: drive hosting partition mounted at GIS_STORE_IMAGE_DIR, or
-   * NULL if it can't be determined
+  /* UDisksDrive or UDisksLoop: drive or loop block device hosting
+   * partition mounted at GIS_STORE_IMAGE_DIR, or NULL if it can't be
+   * determined. Check with UDISKS_IS_DRIVE or UDISKS_IS_LOOP.
    */
-  GIS_STORE_IMAGE_DRIVE,
+  GIS_STORE_IMAGE_SOURCE,
 
   GIS_STORE_N_OBJECTS
 } GISStoreObjectKey;


### PR DESCRIPTION
The requirement to have an actual non-removable disk on hand for testing is pretty onerous. This allows using a loop device for the installation target and ensures that it's not the same if the source is also a loop device.

I feel like you could probably do some automated testing with this presuming that the test was run from a fairly privileged process.