### PR TITLE
finished: use poweroff from PATH

### DIFF
--- a/gnome-image-installer/pages/finished/gis-finished-page.c
+++ b/gnome-image-installer/pages/finished/gis-finished-page.c
@@ -124,7 +124,7 @@ get_customer_support_email (void)
 static void
 reboot_cb (GtkButton *button, GisFinishedPage *page)
 {
-  g_spawn_command_line_sync ("/usr/bin/systemctl poweroff", NULL, NULL, NULL, NULL);
+  g_spawn_command_line_sync ("poweroff", NULL, NULL, NULL, NULL);
   g_application_quit(G_APPLICATION (GIS_PAGE (page)->driver));
 }
 


### PR DESCRIPTION
I'm trying to use eos-installer on a [NixOS][1]-based image.  On NixOS, systemctl isn't in /usr/bin (it's in /run/current-system/sw/bin, but applications aren't supposed to directly hardcode that).  We can be more portable by just assuming that the operating system has PATH set up properly.

While I was there, it made sense to change from running "systemctl poweroff" to just "poweroff", because on systemd systems those are the same thing, but "poweroff" is likely to exist on non-systemd systems.  (I doubt eos-installer would work in its current form without systemd, but it can't hurt to avoid systemd-isms where it's trivial.)

[1]: https://nixos.org/
