### PR TITLE
diskimage: find names for uncompressed image files

### DIFF
--- a/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
+++ b/gnome-image-installer/pages/diskimage/gis-diskimage-page.c
@@ -210,7 +210,7 @@ static gchar *get_display_name(const gchar *fullname)
   GMatchInfo *info;
   gchar *name = NULL;
 
-  reg = g_regex_new ("^.*/([^-]+)-([^-]+)-(?:[^-]+)-(?:[^.]+)\\.(?:[^.]+)\\.([^.]+)(?:\\.(disk\\d))?\\.img(?:\\.([gx]z|asc|sha256))$", 0, 0, NULL);
+  reg = g_regex_new ("^.*/([^-]+)-([^-]+)-(?:[^-]+)-(?:[^.]+)\\.(?:[^.]+)\\.([^.]+)(?:\\.(disk\\d))?\\.img(?:\\.([gx]z|asc|sha256))?$", 0, 0, NULL);
   g_regex_match (reg, fullname, 0, &info);
   if (g_match_info_matches (info))
     {


### PR DESCRIPTION
Uncompressed image files with names ending in .img are already
accepted by add_image(), but the regex for finding the display name
would fail because it didn't understand files without a second
extension after .img.

Uncompressed image files are very useful for my use case: by using a
loopback mount in GRUB (which doesn't work if the image file is
compressed), I can provide the option of booting the image directly
from GRUB as a live image.  The OS I'm working with is special
purpose, and it wouldn't make sense to run eos-installer on it
directly, so eos-installer runs on a standalone standard Linux image
created just for the installer, instead of being part of the live
image like it normally would be.
