### PR TITLE
polkit rules: use non-sugary closure syntax

### DIFF
--- a/eos-installer-data/90-eos-installer.rules
+++ b/eos-installer-data/90-eos-installer.rules
@@ -34,7 +34,7 @@ polkit.addRule(function(action, subject) {
     return undefined;
 });
 
-polkit.addRule((action, subject) => {
+polkit.addRule(function(action, subject) {
     // This rule should check only actions that are not already permitted by
     // 20-gnome-initial-setup.rules, and permit them to both the live user and
     // the gnome-initial-setup user.


### PR DESCRIPTION
Polkit added a ducktape backend in 121 release,
and it looks like it doesn't support the => closures