### PR TITLE
polkit rules: tweak to be ecma 5 compatible

### DIFF
--- a/eos-installer-data/90-eos-installer.rules
+++ b/eos-installer-data/90-eos-installer.rules
@@ -43,13 +43,13 @@ polkit.addRule(function(action, subject) {
         !(subject.user === 'live' && isLiveSystem))
         return undefined;
 
-    const allowedUdisksActions = [
+    var allowedUdisksActions = [
         'org.freedesktop.udisks2.filesystem-mount',
         'org.freedesktop.udisks2.open-device',
         'org.freedesktop.udisks2.open-device-system',
     ];
 
-    if (allowedUdisksActions.includes(action.id) ||
+    if (allowedUdisksActions.indexOf(action.id) >= 0 ||
         (action.id === 'org.freedesktop.policykit.exec' &&
             action.lookup('program') === '/usr/sbin/eos-repartition-mbr')) {
         if (subject.local)


### PR DESCRIPTION
Or how I lost a weekend debugging..

Polkit rules must be ecma 5 compatible [1]

* Use var instead of const for the array
* Use indexOf instead of includes

[1] https://gitlab.freedesktop.org/polkit/polkit/-/blob/master/docs/man/polkit.xml#L504