### PR TITLE
Use absolute binary path in .desktop

### DIFF
--- a/eos-installer-data/meson.build
+++ b/eos-installer-data/meson.build
@@ -1,5 +1,5 @@
 desktop_conf = configuration_data()
-desktop_conf.set('LIBEXECDIR', libexecdir)
+desktop_conf.set('LIBEXECDIR', prefix / libexecdir)
 
 i18n.merge_file(
     input: configure_file(

--- a/eos-installer-data/meson.build
+++ b/eos-installer-data/meson.build
@@ -14,9 +14,6 @@ i18n.merge_file(
     type: 'desktop'
 )
 
-data_conf = configuration_data()
-data_conf.set('libexecdir', libexecdir)
-
 install_data(
     'run-mount-eosimages.mount',
     install_dir: systemdsystemunitdir,


### PR DESCRIPTION
Previously, the Exec line would be set to a relative path like:

```ini
Exec=libexec/gnome-image-installer
```

This will, of course, fail. Set an absolute path here.

While we're here, remove an unused variable.

https://phabricator.endlessm.com/T33912
