### PR TITLE
Fix missing format specifier in Turkish translation

### DIFF
--- a/po/tr.po
+++ b/po/tr.po
@@ -202,7 +202,7 @@ msgstr "Geçerli sürümü kullan:"
 #, no-c-format
 msgid ""
 "The location you have chosen is too small: you need %s to reformat with %s."
-msgstr "Seçtiğiniz konum yetersiz, ihtiyacınız olan %s"
+msgstr "Seçtiğiniz konum yetersiz, ihtiyacınız olan %s ile yeniden formatlamak için %s."
 
 #: ../gnome-image-installer/pages/disktarget/gis-disktarget-page.c:150
 msgid "More than one candidate block device was found."


### PR DESCRIPTION
Recent `msgfmt --check` fails since this translation is missing a format specifier. According to Google Translate, the updated translation is `The location you selected is insufficient, you need %s to reformat with %s.`.

https://phabricator.endlessm.com/T33861