### PR TITLE
finished: Use GNOME Text Editor if present

### DIFF
--- a/gnome-image-installer/util/gis-write-diagnostics.c
+++ b/gnome-image-installer/util/gis-write-diagnostics.c
@@ -146,7 +146,7 @@ write_diagnostics_thread_func (GTask *task,
    * The additional complication is that, when running from the FBE, the user
    * can't get to a file manager or web browser. So there's only any point in
    * saving a log if the user can view it directly from the error page. (In
-   * particular, eosinstaller images do not include gedit or any other GUI text
+   * particular, eosinstaller images do not include any GUI text
    * editor; so, in that case, if we couldn't save to the image partition we
    * should just give up.)
    */


### PR DESCRIPTION
We would like to switch from preinstalling gedit to preinstalling GNOME Text Editor. Check if Text Editor is installed and use it if so; falling back to Gedit.

(For extra credit, we could use
`g_app_info_get_all_for_type ("text/plain")`, but we do want to hardcode a good default because, as explained in the comment, in the Initial Setup session all mime types are associated with `/bin/true` to prevent launching external applications, so we can't rely on `g_app_info_get_default_for_type ("text/plain")` returning something useful.)

https://phabricator.endlessm.com/T32962