### PR TITLE
Increase test timeout

### DIFF
--- a/tests/meson.build
+++ b/tests/meson.build
@@ -155,5 +155,6 @@ foreach test_name, test_options : tests
 
   test(test_name, exe,
     env: test_env,
+    timeout: 300,
   )
 endforeach


### PR DESCRIPTION
I regularly see the scribe test in particular take way longer than the default 30 seconds if my system is otherwise under load.  (For example, if I'm building other packages at the same time as eos-installer.)  Most recently, it took 102s.

Let's increase the test timeout and save me having to restart transiently failing builds. :)